### PR TITLE
[MeTTa] clean up find-evidence-for relation

### DIFF
--- a/metta_nl_corpus/services/spaces/inference-example.metta
+++ b/metta_nl_corpus/services/spaces/inference-example.metta
@@ -36,5 +36,20 @@
 !(entails-contradication? this-swan)
 !(entails-contradication? swan)
 
+!(add-proposition (
+  (=> $A $C)
+  (, (=> $A $B) (=> $B $C))
+  ))
+
+!(all)
+!(deduce-from (, (=> Socrates man) (=> man mortal))) ;; returns [((=> Socrates mortal))]
+
+
+!(add-proposition (=> Socrates man))
+!(add-proposition (=> man mortal))
+!(find-evidence-for (=> Socrates mortal)) ;; returns [(, (=> Socrates man) (=> man mortal))]
+!(find-evidence-for (=> a h)) ;; does not return evidence
+
+
 ;; questions:
 ;; - naming conventions? capital vs lowercase?

--- a/metta_nl_corpus/services/spaces/inference.metta
+++ b/metta_nl_corpus/services/spaces/inference.metta
@@ -18,15 +18,13 @@
 (= (all) (match &a $x $x))
 
 (= (all $expr) (match &a $expr $expr))
-(= (all $expr) (match &a (=> $x $expr) $x)) ; needs actual chainer
+(= (all $expr) (match &a (=> $x $expr) $x))
 
 (= (all $expr $out) (match &a $expr $out))
 (= (all $expr $out) (all (match &a $expr $out)))
 
 ;; 3. find everything which implies $a
-(= (find-evidence-for $a) (
-  let $z (all ($a)) $z
-  ))
+(= (find-evidence-for $a) (all $a))
 
 (= (find-evidence-for $a) (
   let $z (all ($a)) (if (== $z ($a))


### PR DESCRIPTION
Leaf node of 'find-evidence-for' was intoducing unnecessary brackets, such that the method had inconsistent usage.

Now it works as expected (see example)

```
!(find-evidence-for (=> Socrates mortal))
```
returns
```
[(, (=> Socrates man) (=> man mortal))]
```


