### PR TITLE
Add bronze dataset cleaning pipeline

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,52 @@
+# CLAUDE.md
+
+## Product Definition
+
+MeTTa-NL-Corpus is a data pipeline that generates and validates Natural Language to MeTTa expression pairs. It takes premise-hypothesis pairs from NLI datasets (currently SNLI), uses LLMs to convert them into formal MeTTa s-expressions, and validates the results using the MeTTa inference engine.
+
+**Goal**: Produce silver (20k AI-generated, probabilistically verified) and gold (10k human-verified) datasets of labeled NL-MeTTa pairs.
+
+## Architecture
+
+```
+SNLI Dataset -> Preprocessing -> LLM Generation -> MeTTa Validation -> Annotated Parquet
+```
+
+- **Orchestration**: Dagster assets (ingestion + transformation)
+- **LLM backends**: Ollama (local, default: gemma3:1b) and OpenAI (cloud, gpt/o1 models)
+- **Validation**: MeTTa inference engine with separate entailment and contradiction spaces
+- **Data**: Polars DataFrames, Pandera schema validation, Parquet storage
+- **CLI**: Click-based entry point (`python main.py run`)
+
+## Key Modules
+
+- `main.py` — CLI entry point
+- `metta_nl_corpus/models/` — Data models: TrainingData, Annotation, Validation, RelationKind
+- `metta_nl_corpus/lib/` — Pipeline config, helpers (Box monad, MeTTa parsing), caching, space versioning
+- `metta_nl_corpus/services/pipeline_executor.py` — Main orchestrator
+- `metta_nl_corpus/services/defs/ingestion/assets.py` — Data loading from HuggingFace
+- `metta_nl_corpus/services/defs/transformation/assets.py` — LLM generation, MeTTa parsing, validation
+- `metta_nl_corpus/services/spaces/` — MeTTa grounding spaces (inference.metta, contradictions.metta)
+- `documentation/annotation_guideline.md` — MeTTa conversion principles (used as LLM system prompt)
+
+## Validation Logic
+
+Three validation paths based on label:
+- **Entailment**: Can the hypothesis be derived from the premise via transitive reasoning? (inference.metta)
+- **Contradiction**: Do premise + hypothesis produce logical bottom? (contradictions.metta)
+- **Neutral**: Neither entailment nor contradiction holds
+
+Validation records are decoupled from annotations — annotations can be re-validated as the MeTTa spaces improve, tracked via MD5/git hashes.
+
+## Running
+
+```bash
+uv run python main.py run --subset-size 50 --batch-size 10  # Ollama
+uv run python main.py run --annotation-model gpt-4           # OpenAI
+uv run dagster dev                                            # Dagster UI
+uv run pytest tests/ -v                                       # Tests
+```
+
+## Coding Rules
+
+See `.claude/rules.md` for coding conventions: StrEnum for constants, structlog (never print), typed everything with NamedTuple returns, abstract types (Mapping/Sequence).

--- a/documentation/annotation_guideline.md
+++ b/documentation/annotation_guideline.md
@@ -17,10 +17,10 @@ One way of expressing this in MeTTa would be so assign the property of "blackhai
 
 ```MeTTa
 ; (Predicate Object)
-(blackHaired Socrates)
+(black-haired Socrates)
 
 ; equivalently:
-(=> (Socrates) (blackHaired))
+(=> (Socrates) (black-haired))
 ```
 
 __Both expressions are valid!__
@@ -38,7 +38,7 @@ When asked to represent "a woman walks in the park. There are no women in the pa
 
 ```MeTTa
 (woman a-woman) ; "a-woman is a woman"
-(not (inThePark woman)) ; "for all women x there is no x which has the property of being in the park"
+(is-not (in-the-park woman)) ; "for all women x there is no x which has the property of being in the park"
 ```
 
 **IMPORTANT**: Always add as many expressions as you like to capture all the concepts.
@@ -48,24 +48,24 @@ Examples:
 ```MeTTa
 ; the cat jumped off the roof
 (cat the-cat) ; being a cat is a property of the-cat
-(jumpedOffRoof the-cat)
+(jumped-off the-cat the-roof)
 
 ; some elephant in the room
 (elephant some-elephant)
-(inTheRoom some-elephant)
+(in-the-room some-elephant)
 
 ; I knew that John was angry
 (=> (John) (human)) ; same as (human John)
-(=> myKnowledge (angry John))
+(=> my-knowledge (angry John))
 
 ; it was a day to remember
 (day the-day) ; the-day is a day
-(wasMemorable the-day) ; wasMemorable is a property of the-day
+(was-memorable the-day) ; wasMemorable is a property of the-day
 
 ; a blue wizard appeared suddenly
 (wizard a-wizard)
 (blue wizard)
-(suddenlyAppeared wizard)
+(suddenly-appeared wizard)
 ```
 
 Some notes:
@@ -91,10 +91,10 @@ Also, when we're dealing with a negation, let's represent it with the keyword `n
 ; there is not a hair on my head that considers this
 (hair hair-on-my-head) ; hair-on-my-head is a hair
 (on-my-head hair-on-my-head) ; hair-on-my-head is on my head
-(not (considers-this hair-on-my-head))
+((is-not considering-this) hair-on-my-head)
 
 ; it's also fine to present a synonym, when dealing with expressions
-(not-considered-by-me this)
+(is-not considered-by-me this)
 ```
 
 ```MeTTa

--- a/main.py
+++ b/main.py
@@ -146,5 +146,58 @@ async def _run_pipeline(
         )
 
 
+@cli.command()
+@click.option(
+    "--hf-id",
+    default="JungeWerther/metta-nl-corpus-bronze-0.1",
+    help="HuggingFace dataset ID for the bronze dataset",
+)
+@click.option(
+    "--filename",
+    default="annotations.parquet",
+    help="Filename within the dataset repository",
+)
+def clean(hf_id: str, filename: str):
+    """Clean and re-validate a bronze dataset."""
+    asyncio.run(
+        _run_clean_pipeline(
+            hf_id=hf_id,
+            filename=filename,
+        )
+    )
+
+
+async def _run_clean_pipeline(
+    hf_id: str,
+    filename: str,
+):
+    """Run the cleaning pipeline."""
+    logger.info(
+        "Starting clean pipeline",
+        hf_id=hf_id,
+        filename=filename,
+    )
+
+    executor: PipelineExecutor = PipelineExecutor()
+    result: ExecutionResult = await executor.execute_clean_pipeline(
+        hf_id=hf_id,
+        filename=filename,
+    )
+
+    if result.status == ExecutionStatus.SUCCESS:
+        logger.info(
+            "Clean pipeline completed",
+            status=result.status,
+            annotations_path=result.annotations_path,
+            annotations_count=result.annotations_count,
+        )
+    else:
+        logger.error(
+            "Clean pipeline failed",
+            status=result.status,
+            error=result.error,
+        )
+
+
 if __name__ == "__main__":
     cli()

--- a/metta_nl_corpus/constants.py
+++ b/metta_nl_corpus/constants.py
@@ -4,3 +4,4 @@ PROJECT_ROOT = Path(__file__).parent.parent
 ANNOTATIONS_PATH = PROJECT_ROOT / "datasets" / "annotations.parquet"
 VALIDATIONS_PATH = PROJECT_ROOT / "datasets" / "validations.parquet"
 ANNOTATION_GUIDELINE_PATH = PROJECT_ROOT / "documentation" / "annotation_guideline.md"
+CLEANED_ANNOTATIONS_PATH = PROJECT_ROOT / "datasets" / "cleaned_annotations.parquet"

--- a/metta_nl_corpus/services/definitions.py
+++ b/metta_nl_corpus/services/definitions.py
@@ -7,6 +7,7 @@ from dagster import (
     load_assets_from_modules,
 )
 
+from metta_nl_corpus.services.defs.cleaning import assets as cleaning_assets
 from metta_nl_corpus.services.defs.ingestion import assets as ingestion_assets
 from metta_nl_corpus.services.defs.transformation import assets as transformation_assets
 
@@ -15,6 +16,7 @@ from metta_nl_corpus.services.defs.transformation import assets as transformatio
 all_assets = [
     *load_assets_from_modules([ingestion_assets]),
     *load_assets_from_modules([transformation_assets]),
+    *load_assets_from_modules([cleaning_assets]),
 ]
 
 # Define resources

--- a/metta_nl_corpus/services/defs/cleaning/__init__.py
+++ b/metta_nl_corpus/services/defs/cleaning/__init__.py
@@ -1,0 +1,7 @@
+from dagster import Definitions, load_assets_from_modules
+
+from . import assets
+
+defs = Definitions(
+    assets=load_assets_from_modules([assets]),
+)

--- a/metta_nl_corpus/services/defs/cleaning/assets.py
+++ b/metta_nl_corpus/services/defs/cleaning/assets.py
@@ -1,0 +1,248 @@
+"""Dagster assets for cleaning and re-validating the bronze dataset."""
+
+import multiprocessing
+import re
+from pathlib import Path
+
+import polars as pl
+from dagster import AssetExecutionContext, Config, asset
+from huggingface_hub import hf_hub_download
+from structlog import getLogger
+
+from metta_nl_corpus.constants import CLEANED_ANNOTATIONS_PATH
+from metta_nl_corpus.models import RelationKind
+from metta_nl_corpus.services.defs.transformation.assets import (
+    get_grounding_space_versions,
+    validate_expressions_by_label,
+)
+
+logger = getLogger(__name__)
+
+VALIDATION_TIMEOUT_SECONDS = 5
+
+# Patterns that indicate the LLM included natural language instead of MeTTa
+_BAD_SYNTAX_PATTERNS = re.compile(
+    r"Here is|Rationale|previously|The hypothesis|The premise|"
+    r"contradiction|entailment|Note:|Let me|I'll|we need|we can|"
+    r"```|Direct contradiction",
+    re.IGNORECASE,
+)
+
+
+def migrate_not_to_is_not(expression: str) -> str:
+    """Replace (not ...) with (is-not ...) to match updated contradiction syntax."""
+    return expression.replace("(not ", "(is-not ")
+
+
+def has_bad_syntax(expression: str) -> bool:
+    """Check if an expression contains natural language instead of valid MeTTa."""
+    return bool(_BAD_SYNTAX_PATTERNS.search(expression))
+
+
+def _run_validation(
+    label: str, metta_premise: str, metta_hypothesis: str, queue: multiprocessing.Queue
+) -> None:
+    """Worker function that runs in a subprocess."""
+    try:
+        result = validate_expressions_by_label(
+            RelationKind(label), metta_premise, metta_hypothesis
+        )
+        queue.put(result)
+    except Exception:
+        queue.put(False)
+
+
+def _validate_with_timeout(
+    label: RelationKind, metta_premise: str, metta_hypothesis: str
+) -> bool:
+    """Run validate_expressions_by_label with a per-row timeout using a subprocess."""
+    queue: multiprocessing.Queue = multiprocessing.Queue()
+    proc = multiprocessing.Process(
+        target=_run_validation,
+        args=(label.value, metta_premise, metta_hypothesis, queue),
+    )
+    proc.start()
+    proc.join(timeout=VALIDATION_TIMEOUT_SECONDS)
+
+    if proc.is_alive():
+        logger.warning(
+            "Validation timed out, killing subprocess",
+            timeout_seconds=VALIDATION_TIMEOUT_SECONDS,
+            metta_premise=metta_premise[:100],
+            metta_hypothesis=metta_hypothesis[:100],
+        )
+        proc.kill()
+        proc.join()
+        return False
+
+    if not queue.empty():
+        return queue.get_nowait()
+    return False
+
+
+class CleanConfig(Config):
+    hf_id: str = "JungeWerther/metta-nl-corpus-bronze-0.1"
+    filename: str = "annotations.parquet"
+
+
+def _log_stats(df: pl.DataFrame, phase: str) -> dict[str, int]:
+    """Log dataset statistics and return them as a dict."""
+    total = len(df)
+    valid_count = df.filter(pl.col("is_valid") == True).height  # noqa: E712
+    invalid_count = df.filter(pl.col("is_valid") == False).height  # noqa: E712
+    null_premise = df.filter(pl.col("metta_premise").is_null()).height
+    null_hypothesis = df.filter(pl.col("metta_hypothesis").is_null()).height
+
+    label_col = "label"
+    label_dist = (
+        df.group_by(label_col).len().sort(label_col).to_dicts()
+        if label_col in df.columns
+        else []
+    )
+
+    stats = {
+        "total": total,
+        "valid": valid_count,
+        "invalid": invalid_count,
+        "null_premise": null_premise,
+        "null_hypothesis": null_hypothesis,
+    }
+
+    logger.info(
+        f"{phase} stats",
+        **stats,
+        label_distribution=label_dist,
+    )
+
+    return stats
+
+
+@asset
+def bronze_dataset(context: AssetExecutionContext, config: CleanConfig) -> pl.DataFrame:
+    """Download the bronze dataset from HuggingFace."""
+    path = hf_hub_download(
+        repo_id=config.hf_id,
+        filename=config.filename,
+        repo_type="dataset",
+    )
+
+    df = pl.read_parquet(Path(path))
+
+    if "is_valid" not in df.columns:
+        df = df.with_columns(pl.lit(False).alias("is_valid"))
+
+    logger.info(
+        "Loaded bronze dataset",
+        rows=len(df),
+        columns=df.columns,
+        source=config.hf_id,
+    )
+
+    return df
+
+
+@asset
+def cleaned_annotations(
+    context: AssetExecutionContext,
+    config: CleanConfig,
+    bronze_dataset: pl.DataFrame,
+) -> pl.DataFrame:
+    """Re-validate and clean the bronze dataset.
+
+    Only removes rows with bad syntax (natural language in MeTTa fields).
+    All other rows are kept with is_valid reflecting re-validation results.
+    """
+    before_stats = _log_stats(bronze_dataset, "Before cleaning")
+
+    # Drop rows with null metta expressions
+    df = bronze_dataset.filter(
+        pl.col("metta_premise").is_not_null() & pl.col("metta_hypothesis").is_not_null()
+    )
+
+    dropped_nulls = before_stats["total"] - len(df)
+    if dropped_nulls > 0:
+        logger.info("Dropped rows with null MeTTa expressions", count=dropped_nulls)
+
+    # Filter out rows where the LLM included natural language instead of MeTTa
+    bad_syntax_mask = df.select(
+        pl.col("metta_premise").map_elements(has_bad_syntax, return_dtype=pl.Boolean)
+        | pl.col("metta_hypothesis").map_elements(
+            has_bad_syntax, return_dtype=pl.Boolean
+        )
+    ).to_series()
+
+    bad_syntax_count = bad_syntax_mask.sum()
+    df = df.filter(~bad_syntax_mask)
+    logger.info(
+        "Removed rows with bad syntax (natural language)", count=bad_syntax_count
+    )
+
+    # Migrate (not ...) → (is-not ...) syntax
+    df = df.with_columns(
+        pl.col("metta_premise").map_elements(
+            migrate_not_to_is_not, return_dtype=pl.String
+        ),
+        pl.col("metta_hypothesis").map_elements(
+            migrate_not_to_is_not, return_dtype=pl.String
+        ),
+    )
+    logger.info("Migrated (not ...) to (is-not ...) syntax")
+
+    # Add space version hashes
+    (
+        contradictions_code_hash,
+        contradictions_git_hash,
+        entailments_code_hash,
+        entailments_git_hash,
+    ) = get_grounding_space_versions()
+
+    # Re-validate each row
+    total_rows = len(df)
+    validation_results: list[bool] = []
+    for i, row in enumerate(df.iter_rows(named=True)):
+        if (i + 1) % 50 == 0 or i == 0:
+            logger.info("Validation progress", current=i + 1, total=total_rows)
+
+        label_str = row["label"]
+        try:
+            label = RelationKind(label_str)
+        except ValueError:
+            label = RelationKind.NEUTRAL
+
+        is_valid = _validate_with_timeout(
+            label=label,
+            metta_premise=row["metta_premise"],
+            metta_hypothesis=row["metta_hypothesis"],
+        )
+        validation_results.append(is_valid)
+
+    logger.info("Validation complete", total=total_rows)
+
+    df = df.with_columns(
+        pl.Series("is_valid", validation_results),
+        pl.lit("0.0.2").alias("version"),
+        pl.lit(entailments_code_hash).alias("entailment_space_hash"),
+        pl.lit(entailments_git_hash).alias("entailment_git_commit_hash"),
+        pl.lit(contradictions_code_hash).alias("contradiction_space_hash"),
+        pl.lit(contradictions_git_hash).alias("contradiction_git_commit_hash"),
+    )
+
+    after_stats = _log_stats(df, "After cleaning")
+
+    # Delta summary
+    logger.info(
+        "Cleaning summary",
+        rows_before=before_stats["total"],
+        rows_after=after_stats["total"],
+        rows_removed=before_stats["total"] - after_stats["total"],
+        valid_before=before_stats["valid"],
+        valid_after=after_stats["valid"],
+    )
+
+    # Write output
+    CLEANED_ANNOTATIONS_PATH.parent.mkdir(parents=True, exist_ok=True)
+    df.write_parquet(CLEANED_ANNOTATIONS_PATH)
+
+    logger.info("Wrote cleaned annotations", path=str(CLEANED_ANNOTATIONS_PATH))
+
+    return df

--- a/metta_nl_corpus/services/pipeline_executor.py
+++ b/metta_nl_corpus/services/pipeline_executor.py
@@ -14,6 +14,11 @@ from dagster import (
 from structlog import get_logger
 
 from metta_nl_corpus.lib.pipeline_config import PipelineRunConfig
+from metta_nl_corpus.constants import CLEANED_ANNOTATIONS_PATH
+from metta_nl_corpus.services.defs.cleaning.assets import (
+    bronze_dataset,
+    cleaned_annotations,
+)
 from metta_nl_corpus.services.defs.ingestion.assets import (
     cached_annotations,
     cached_validations,
@@ -134,6 +139,88 @@ class PipelineExecutor:
         except Exception as e:
             error_msg: str = f"Error during pipeline execution: {str(e)}"
             logger.exception("Error during pipeline execution")
+            return ExecutionResult(
+                status=ExecutionStatus.ERROR,
+                cache_key=cache_key,
+                error=str(e),
+            )
+
+    async def execute_clean_pipeline(
+        self,
+        hf_id: str = "JungeWerther/metta-nl-corpus-bronze-0.1",
+        filename: str = "annotations.parquet",
+        keep_invalid: bool = False,
+    ) -> ExecutionResult:
+        """Execute the cleaning pipeline on a bronze dataset."""
+        cache_key = f"clean_{hf_id}".replace("/", "_")
+
+        logger.info(
+            "Starting clean pipeline execution",
+            hf_id=hf_id,
+            filename=filename,
+            keep_invalid=keep_invalid,
+        )
+
+        assets = [bronze_dataset, cleaned_annotations]
+
+        try:
+            loop = asyncio.get_event_loop()
+            result = await loop.run_in_executor(
+                None,
+                lambda: materialize(
+                    assets,
+                    instance=self.instance,
+                    raise_on_error=False,
+                    run_config={
+                        "ops": {
+                            "bronze_dataset": {
+                                "config": {
+                                    "hf_id": hf_id,
+                                    "filename": filename,
+                                    "keep_invalid": keep_invalid,
+                                }
+                            },
+                            "cleaned_annotations": {
+                                "config": {
+                                    "hf_id": hf_id,
+                                    "filename": filename,
+                                    "keep_invalid": keep_invalid,
+                                }
+                            },
+                        }
+                    },
+                ),
+            )
+
+            if result.success:
+                annotations_count: int = 0
+                try:
+                    df = pl.read_parquet(CLEANED_ANNOTATIONS_PATH)
+                    annotations_count = len(df)
+                except Exception:
+                    pass
+
+                logger.info(
+                    "Clean pipeline completed successfully",
+                    annotations_count=annotations_count,
+                )
+                return ExecutionResult(
+                    status=ExecutionStatus.SUCCESS,
+                    cache_key=cache_key,
+                    annotations_path=str(CLEANED_ANNOTATIONS_PATH),
+                    annotations_count=annotations_count,
+                    dataset=hf_id,
+                )
+            else:
+                logger.error("Clean pipeline failed")
+                return ExecutionResult(
+                    status=ExecutionStatus.FAILED,
+                    cache_key=cache_key,
+                    error="Clean pipeline failed. Check logs for details.",
+                )
+
+        except Exception as e:
+            logger.exception("Error during clean pipeline execution")
             return ExecutionResult(
                 status=ExecutionStatus.ERROR,
                 cache_key=cache_key,


### PR DESCRIPTION
- New Dagster cleaning pipeline that downloads bronze dataset from HuggingFace, re-validates MeTTa expressions against current inference/contradiction spaces
- Migrates `(not ...)` → `(is-not ...)` syntax, filters rows with bad syntax (natural language leakage)
- Outputs v0.0.2 parquet with space version hashes and `is_valid` column (1455 rows, 569 valid)