### PR TITLE
Migrate annotation storage from parquet to SQLite

### DIFF
--- a/metta_nl_corpus/constants.py
+++ b/metta_nl_corpus/constants.py
@@ -2,6 +2,7 @@ from pathlib import Path
 
 PROJECT_ROOT = Path(__file__).parent.parent
 ANNOTATIONS_PATH = PROJECT_ROOT / "datasets" / "annotations.parquet"
+ANNOTATIONS_DB_PATH = PROJECT_ROOT / "datasets" / "annotations.db"
 VALIDATIONS_PATH = PROJECT_ROOT / "datasets" / "validations.parquet"
 ANNOTATION_GUIDELINE_PATH = PROJECT_ROOT / "documentation" / "annotation_guideline.md"
 CLEANED_ANNOTATIONS_PATH = PROJECT_ROOT / "datasets" / "cleaned_annotations.parquet"

--- a/metta_nl_corpus/lib/storage.py
+++ b/metta_nl_corpus/lib/storage.py
@@ -1,0 +1,265 @@
+"""SQLite-backed annotation storage with WAL mode for concurrent access.
+
+Replaces the parquet read-modify-write pattern that corrupts data under
+concurrent asyncio.gather writes. SQLite in WAL mode provides ACID
+guarantees with single-writer/multi-reader concurrency.
+"""
+
+from __future__ import annotations
+
+import sqlite3
+import threading
+from pathlib import Path
+from typing import Any
+
+import polars as pl
+from structlog import get_logger
+
+logger = get_logger(__name__)
+
+# Column definitions matching the Pandera Annotation/Validation models.
+_ANNOTATIONS_COLUMNS: list[tuple[str, str]] = [
+    ("annotation_id", "TEXT PRIMARY KEY"),
+    ("idx", "INTEGER NOT NULL"),  # 'index' is reserved in SQL
+    ("premise", "TEXT"),
+    ("hypothesis", "TEXT"),
+    ("label", "TEXT"),
+    ("metta_premise", "TEXT"),
+    ("metta_hypothesis", "TEXT"),
+    ("generation_model", "TEXT"),
+    ("system_prompt", "TEXT"),
+    ("version", "TEXT"),
+    ("is_valid", "INTEGER"),  # SQLite has no native bool
+    ("input_tokens", "INTEGER"),
+    ("output_tokens", "INTEGER"),
+    ("fix_reason", "TEXT"),
+]
+
+_VALIDATIONS_COLUMNS: list[tuple[str, str]] = [
+    ("validation_id", "TEXT PRIMARY KEY"),
+    ("annotation_id", "TEXT NOT NULL"),
+    ("is_valid", "INTEGER NOT NULL"),
+    ("relation_kind", "TEXT"),
+    ("entailment_space_hash", "TEXT"),
+    ("entailment_git_commit_hash", "TEXT"),
+    ("contradiction_space_hash", "TEXT"),
+    ("contradiction_git_commit_hash", "TEXT"),
+    ("validation_timestamp", "TEXT"),
+]
+
+# Maps between the Polars/Pandera column name 'index' and the SQLite column 'idx'.
+_PL_TO_SQL = {"index": "idx"}
+_SQL_TO_PL = {"idx": "index"}
+
+
+class AnnotationStore:
+    """Thread-safe SQLite store for annotations and validations."""
+
+    def __init__(self, db_path: Path) -> None:
+        self.db_path = db_path
+        db_path.parent.mkdir(parents=True, exist_ok=True)
+        self._local = threading.local()
+        # Eagerly create tables on the main thread's connection.
+        conn = self._get_conn()
+        conn.execute("PRAGMA journal_mode=WAL")
+        conn.execute("PRAGMA busy_timeout=5000")
+        self._create_tables(conn)
+
+    # -- connection management -------------------------------------------------
+
+    def _get_conn(self) -> sqlite3.Connection:
+        """Return a per-thread connection (created lazily)."""
+        conn: sqlite3.Connection | None = getattr(self._local, "conn", None)
+        if conn is None:
+            conn = sqlite3.connect(str(self.db_path), check_same_thread=False)
+            conn.execute("PRAGMA journal_mode=WAL")
+            conn.execute("PRAGMA busy_timeout=5000")
+            conn.row_factory = sqlite3.Row
+            self._local.conn = conn
+        return conn
+
+    # -- schema ----------------------------------------------------------------
+
+    def _create_tables(self, conn: sqlite3.Connection) -> None:
+        cols_a = ", ".join(f"{name} {typ}" for name, typ in _ANNOTATIONS_COLUMNS)
+        conn.execute(f"CREATE TABLE IF NOT EXISTS annotations ({cols_a})")
+
+        cols_v = ", ".join(f"{name} {typ}" for name, typ in _VALIDATIONS_COLUMNS)
+        conn.execute(f"CREATE TABLE IF NOT EXISTS validations ({cols_v})")
+        conn.commit()
+
+    # -- annotations -----------------------------------------------------------
+
+    def insert_annotation(self, row: dict[str, Any]) -> str:
+        """INSERT a single annotation row. Returns the annotation_id."""
+        conn = self._get_conn()
+        mapped = {_PL_TO_SQL.get(k, k): v for k, v in row.items()}
+        # Only keep columns that exist in the table.
+        col_names = [c[0] for c in _ANNOTATIONS_COLUMNS]
+        filtered = {k: v for k, v in mapped.items() if k in col_names}
+        # Convert bools for SQLite.
+        if "is_valid" in filtered and isinstance(filtered["is_valid"], bool):
+            filtered["is_valid"] = int(filtered["is_valid"])
+
+        cols = ", ".join(filtered.keys())
+        placeholders = ", ".join("?" for _ in filtered)
+        conn.execute(
+            f"INSERT OR REPLACE INTO annotations ({cols}) VALUES ({placeholders})",
+            list(filtered.values()),
+        )
+        conn.commit()
+        logger.debug("Inserted annotation", annotation_id=filtered.get("annotation_id"))
+        return str(filtered.get("annotation_id", ""))
+
+    def update_annotation(self, annotation_id: str, updates: dict[str, Any]) -> None:
+        """UPDATE specific columns of an annotation by annotation_id."""
+        conn = self._get_conn()
+        mapped = {_PL_TO_SQL.get(k, k): v for k, v in updates.items()}
+        if "is_valid" in mapped and isinstance(mapped["is_valid"], bool):
+            mapped["is_valid"] = int(mapped["is_valid"])
+        set_clause = ", ".join(f"{k} = ?" for k in mapped)
+        conn.execute(
+            f"UPDATE annotations SET {set_clause} WHERE annotation_id = ?",
+            [*mapped.values(), annotation_id],
+        )
+        conn.commit()
+
+    def get_annotation(self, annotation_id: str) -> dict[str, Any] | None:
+        """Fetch a single annotation by id, or None."""
+        conn = self._get_conn()
+        cur = conn.execute(
+            "SELECT * FROM annotations WHERE annotation_id = ?", (annotation_id,)
+        )
+        row = cur.fetchone()
+        if row is None:
+            return None
+        return self._row_to_dict(dict(row), source="annotations")
+
+    def query(
+        self,
+        table: str = "annotations",
+        filter_column: str | None = None,
+        filter_value: str | None = None,
+        limit: int = 20,
+    ) -> dict[str, Any]:
+        """SELECT with optional filter. Returns {total, returned, columns, rows}."""
+        conn = self._get_conn()
+        valid_tables = {"annotations", "validations"}
+        if table not in valid_tables:
+            return {"error": f"Unknown table '{table}'. Use: {', '.join(valid_tables)}"}
+
+        # Map Polars column names to SQL column names for filtering.
+        sql_filter_col = (
+            _PL_TO_SQL.get(filter_column, filter_column) if filter_column else None
+        )
+
+        # Total count
+        if sql_filter_col and filter_value:
+            cur = conn.execute(
+                f"SELECT COUNT(*) FROM {table} WHERE {sql_filter_col} = ?",
+                (filter_value,),
+            )
+        else:
+            cur = conn.execute(f"SELECT COUNT(*) FROM {table}")
+        total = cur.fetchone()[0]
+
+        # Fetch rows
+        if sql_filter_col and filter_value:
+            cur = conn.execute(
+                f"SELECT * FROM {table} WHERE {sql_filter_col} = ? LIMIT ?",
+                (filter_value, limit),
+            )
+        else:
+            cur = conn.execute(f"SELECT * FROM {table} LIMIT ?", (limit,))
+
+        rows = [self._row_to_dict(dict(r), source=table) for r in cur.fetchall()]
+        col_names = (
+            [_SQL_TO_PL.get(c[0], c[0]) for c in _ANNOTATIONS_COLUMNS]
+            if table == "annotations"
+            else [c[0] for c in _VALIDATIONS_COLUMNS]
+        )
+
+        return {
+            "total": total,
+            "returned": len(rows),
+            "columns": col_names,
+            "rows": rows,
+        }
+
+    # -- validations -----------------------------------------------------------
+
+    def insert_validation(self, row: dict[str, Any]) -> str:
+        """INSERT a single validation row. Returns the validation_id."""
+        conn = self._get_conn()
+        col_names = [c[0] for c in _VALIDATIONS_COLUMNS]
+        filtered = {k: v for k, v in row.items() if k in col_names}
+        if "is_valid" in filtered and isinstance(filtered["is_valid"], bool):
+            filtered["is_valid"] = int(filtered["is_valid"])
+
+        cols = ", ".join(filtered.keys())
+        placeholders = ", ".join("?" for _ in filtered)
+        conn.execute(
+            f"INSERT OR REPLACE INTO validations ({cols}) VALUES ({placeholders})",
+            list(filtered.values()),
+        )
+        conn.commit()
+        return str(filtered.get("validation_id", ""))
+
+    # -- export / import -------------------------------------------------------
+
+    def to_polars(self, table: str = "annotations") -> pl.DataFrame:
+        """Export full table as a Polars DataFrame."""
+        conn = self._get_conn()
+        cur = conn.execute(f"SELECT * FROM {table}")
+        rows = cur.fetchall()
+        if not rows:
+            return pl.DataFrame()
+        dicts = [self._row_to_dict(dict(r), source=table) for r in rows]
+        # Use a generous infer_schema_length to handle mixed types
+        return pl.DataFrame(dicts, infer_schema_length=len(dicts))
+
+    def export_parquet(self, path: Path, table: str = "annotations") -> int:
+        """Export table to parquet. Returns row count."""
+        df = self.to_polars(table)
+        if df.is_empty():
+            logger.info("Nothing to export", table=table)
+            return 0
+        path.parent.mkdir(parents=True, exist_ok=True)
+        df.write_parquet(path)
+        logger.info("Exported to parquet", path=str(path), rows=len(df))
+        return len(df)
+
+    def import_parquet(self, path: Path, table: str = "annotations") -> int:
+        """Import rows from a parquet file. Returns number of rows imported."""
+        if not path.exists():
+            logger.warning("Parquet file not found", path=str(path))
+            return 0
+        df = pl.read_parquet(path)
+        count = 0
+        for row in df.to_dicts():
+            if table == "annotations":
+                self.insert_annotation(row)
+            else:
+                self.insert_validation(row)
+            count += 1
+        logger.info("Imported from parquet", path=str(path), rows=count, table=table)
+        return count
+
+    # -- helpers ---------------------------------------------------------------
+
+    @staticmethod
+    def _row_to_dict(
+        row: dict[str, Any], source: str = "annotations"
+    ) -> dict[str, Any]:
+        """Convert a SQLite row dict back to Polars-compatible column names and types."""
+        if source == "annotations":
+            # Rename idx -> index
+            if "idx" in row:
+                row["index"] = row.pop("idx")
+            # Convert is_valid back to bool
+            if "is_valid" in row and row["is_valid"] is not None:
+                row["is_valid"] = bool(row["is_valid"])
+        elif source == "validations":
+            if "is_valid" in row and row["is_valid"] is not None:
+                row["is_valid"] = bool(row["is_valid"])
+        return row

--- a/metta_nl_corpus/lib/storage.py
+++ b/metta_nl_corpus/lib/storage.py
@@ -13,43 +13,49 @@ from pathlib import Path
 from typing import Any
 
 import polars as pl
+from pandera.polars import DataFrameModel
 from structlog import get_logger
 
+from metta_nl_corpus.models import Annotation, Validation
+
 logger = get_logger(__name__)
-
-# Column definitions matching the Pandera Annotation/Validation models.
-_ANNOTATIONS_COLUMNS: list[tuple[str, str]] = [
-    ("annotation_id", "TEXT PRIMARY KEY"),
-    ("idx", "INTEGER NOT NULL"),  # 'index' is reserved in SQL
-    ("premise", "TEXT"),
-    ("hypothesis", "TEXT"),
-    ("label", "TEXT"),
-    ("metta_premise", "TEXT"),
-    ("metta_hypothesis", "TEXT"),
-    ("generation_model", "TEXT"),
-    ("system_prompt", "TEXT"),
-    ("version", "TEXT"),
-    ("is_valid", "INTEGER"),  # SQLite has no native bool
-    ("input_tokens", "INTEGER"),
-    ("output_tokens", "INTEGER"),
-    ("fix_reason", "TEXT"),
-]
-
-_VALIDATIONS_COLUMNS: list[tuple[str, str]] = [
-    ("validation_id", "TEXT PRIMARY KEY"),
-    ("annotation_id", "TEXT NOT NULL"),
-    ("is_valid", "INTEGER NOT NULL"),
-    ("relation_kind", "TEXT"),
-    ("entailment_space_hash", "TEXT"),
-    ("entailment_git_commit_hash", "TEXT"),
-    ("contradiction_space_hash", "TEXT"),
-    ("contradiction_git_commit_hash", "TEXT"),
-    ("validation_timestamp", "TEXT"),
-]
 
 # Maps between the Polars/Pandera column name 'index' and the SQLite column 'idx'.
 _PL_TO_SQL = {"index": "idx"}
 _SQL_TO_PL = {"idx": "index"}
+
+# Primary key column for each table.
+_PRIMARY_KEYS = {"annotations": "annotation_id", "validations": "validation_id"}
+
+# Polars dtype string -> SQLite type.
+_DTYPE_MAP: dict[str, str] = {
+    "String": "TEXT",
+    "Utf8": "TEXT",
+    "UInt32": "INTEGER",
+    "Int64": "INTEGER",
+    "Boolean": "INTEGER",  # SQLite has no native bool
+}
+
+
+def _columns_from_model(
+    model: type[DataFrameModel],
+    pk: str,
+) -> list[tuple[str, str]]:
+    """Derive SQLite column definitions from a Pandera DataFrameModel."""
+    schema = model.to_schema()
+    columns: list[tuple[str, str]] = []
+    for name, field in schema.columns.items():
+        sql_name = _PL_TO_SQL.get(name, name)
+        sql_type = _DTYPE_MAP.get(str(field.dtype), "TEXT")
+        constraints = " PRIMARY KEY" if name == pk else ""
+        if not field.nullable and field.required and not constraints:
+            constraints = " NOT NULL"
+        columns.append((sql_name, f"{sql_type}{constraints}"))
+    return columns
+
+
+_ANNOTATIONS_COLUMNS = _columns_from_model(Annotation, _PRIMARY_KEYS["annotations"])
+_VALIDATIONS_COLUMNS = _columns_from_model(Validation, _PRIMARY_KEYS["validations"])
 
 
 class AnnotationStore:

--- a/metta_nl_corpus/mcp_server.py
+++ b/metta_nl_corpus/mcp_server.py
@@ -17,11 +17,13 @@ from structlog import get_logger
 
 from metta_nl_corpus.constants import (
     ANNOTATION_GUIDELINE_PATH,
+    ANNOTATIONS_DB_PATH,
     ANNOTATIONS_PATH,
     PROJECT_ROOT,
     VALIDATIONS_PATH,
 )
 from metta_nl_corpus.lib.helpers import parse_all
+from metta_nl_corpus.lib.storage import AnnotationStore
 from metta_nl_corpus.models import RelationKind
 
 logger = get_logger(__name__)
@@ -41,6 +43,13 @@ mcp = FastMCP(
         "from natural language sentences via add_expressions."
     ),
 )
+
+
+# ---------------------------------------------------------------------------
+# SQLite-backed annotation store (replaces parquet read-modify-write)
+# ---------------------------------------------------------------------------
+
+store = AnnotationStore(ANNOTATIONS_DB_PATH)
 
 
 # ---------------------------------------------------------------------------
@@ -128,8 +137,8 @@ def add_expressions(
     annotation_id = str(uuid.uuid4())
     system_prompt = ANNOTATION_GUIDELINE_PATH.read_text()
 
-    row = pl.DataFrame(
-        [
+    try:
+        store.insert_annotation(
             {
                 "annotation_id": annotation_id,
                 "index": 0,
@@ -145,39 +154,13 @@ def add_expressions(
                 "input_tokens": None,
                 "output_tokens": None,
             }
-        ],
-        schema={
-            "annotation_id": pl.Utf8,
-            "index": pl.UInt32,
-            "premise": pl.Utf8,
-            "hypothesis": pl.Utf8,
-            "label": pl.Utf8,
-            "metta_premise": pl.Utf8,
-            "metta_hypothesis": pl.Utf8,
-            "generation_model": pl.Utf8,
-            "system_prompt": pl.Utf8,
-            "version": pl.Utf8,
-            "is_valid": pl.Boolean,
-            "input_tokens": pl.Int64,
-            "output_tokens": pl.Int64,
-        },
-    )
-
-    try:
-        if ANNOTATIONS_PATH.exists():
-            existing = pl.read_parquet(ANNOTATIONS_PATH)
-            combined = pl.concat([existing, row], how="diagonal_relaxed")
-        else:
-            ANNOTATIONS_PATH.parent.mkdir(parents=True, exist_ok=True)
-            combined = row
-        combined.write_parquet(ANNOTATIONS_PATH)
+        )
         logger.info(
-            "Appended ontology annotation",
+            "Stored ontology annotation",
             annotation_id=annotation_id,
-            path=str(ANNOTATIONS_PATH),
         )
     except Exception as e:
-        return {"success": False, "error": f"Failed to write parquet: {e}"}
+        return {"success": False, "error": f"Failed to store annotation: {e}"}
 
     return {
         "success": True,
@@ -240,8 +223,8 @@ def execute_metta(
         annotation_id = str(uuid.uuid4())
         system_prompt = ANNOTATION_GUIDELINE_PATH.read_text()
 
-        row = pl.DataFrame(
-            [
+        try:
+            store.insert_annotation(
                 {
                     "annotation_id": annotation_id,
                     "index": 0,
@@ -257,37 +240,11 @@ def execute_metta(
                     "input_tokens": None,
                     "output_tokens": None,
                 }
-            ],
-            schema={
-                "annotation_id": pl.Utf8,
-                "index": pl.UInt32,
-                "premise": pl.Utf8,
-                "hypothesis": pl.Utf8,
-                "label": pl.Utf8,
-                "metta_premise": pl.Utf8,
-                "metta_hypothesis": pl.Utf8,
-                "generation_model": pl.Utf8,
-                "system_prompt": pl.Utf8,
-                "version": pl.Utf8,
-                "is_valid": pl.Boolean,
-                "input_tokens": pl.Int64,
-                "output_tokens": pl.Int64,
-            },
-        )
-
-        try:
-            if ANNOTATIONS_PATH.exists():
-                existing = pl.read_parquet(ANNOTATIONS_PATH)
-                combined = pl.concat([existing, row], how="diagonal_relaxed")
-            else:
-                ANNOTATIONS_PATH.parent.mkdir(parents=True, exist_ok=True)
-                combined = row
-            combined.write_parquet(ANNOTATIONS_PATH)
+            )
             logger.info(
                 "Stored execute_metta annotation",
                 annotation_id=annotation_id,
                 premise=premise,
-                path=str(ANNOTATIONS_PATH),
             )
             response["annotation_id"] = annotation_id
         except Exception as e:
@@ -345,8 +302,8 @@ def validate_relation(
     annotation_id = str(uuid.uuid4())
     system_prompt = ANNOTATION_GUIDELINE_PATH.read_text()
 
-    row = pl.DataFrame(
-        [
+    try:
+        store.insert_annotation(
             {
                 "annotation_id": annotation_id,
                 "index": 0,
@@ -362,37 +319,11 @@ def validate_relation(
                 "input_tokens": None,
                 "output_tokens": None,
             }
-        ],
-        schema={
-            "annotation_id": pl.Utf8,
-            "index": pl.UInt32,
-            "premise": pl.Utf8,
-            "hypothesis": pl.Utf8,
-            "label": pl.Utf8,
-            "metta_premise": pl.Utf8,
-            "metta_hypothesis": pl.Utf8,
-            "generation_model": pl.Utf8,
-            "system_prompt": pl.Utf8,
-            "version": pl.Utf8,
-            "is_valid": pl.Boolean,
-            "input_tokens": pl.Int64,
-            "output_tokens": pl.Int64,
-        },
-    )
-
-    try:
-        if ANNOTATIONS_PATH.exists():
-            existing = pl.read_parquet(ANNOTATIONS_PATH)
-            combined = pl.concat([existing, row], how="diagonal_relaxed")
-        else:
-            ANNOTATIONS_PATH.parent.mkdir(parents=True, exist_ok=True)
-            combined = row
-        combined.write_parquet(ANNOTATIONS_PATH)
+        )
         logger.info(
             "Stored validated annotation",
             annotation_id=annotation_id,
             is_valid=is_valid,
-            path=str(ANNOTATIONS_PATH),
         )
     except Exception as e:
         logger.error("Failed to store annotation", error=str(e))
@@ -471,9 +402,9 @@ async def ask_metta_agent(
     input_tokens = getattr(usage, "input_tokens", None)
     output_tokens = getattr(usage, "output_tokens", None)
 
-    # Append to annotations parquet
-    row = pl.DataFrame(
-        [
+    # Store annotation
+    try:
+        store.insert_annotation(
             {
                 "annotation_id": str(uuid.uuid4()),
                 "index": 0,
@@ -489,35 +420,10 @@ async def ask_metta_agent(
                 "input_tokens": input_tokens,
                 "output_tokens": output_tokens,
             }
-        ],
-        schema={
-            "annotation_id": pl.Utf8,
-            "index": pl.UInt32,
-            "premise": pl.Utf8,
-            "hypothesis": pl.Utf8,
-            "label": pl.Utf8,
-            "metta_premise": pl.Utf8,
-            "metta_hypothesis": pl.Utf8,
-            "generation_model": pl.Utf8,
-            "system_prompt": pl.Utf8,
-            "version": pl.Utf8,
-            "is_valid": pl.Boolean,
-            "input_tokens": pl.Int64,
-            "output_tokens": pl.Int64,
-        },
-    )
-
-    try:
-        if ANNOTATIONS_PATH.exists():
-            existing = pl.read_parquet(ANNOTATIONS_PATH)
-            combined = pl.concat([existing, row], how="diagonal_relaxed")
-        else:
-            ANNOTATIONS_PATH.parent.mkdir(parents=True, exist_ok=True)
-            combined = row
-        combined.write_parquet(ANNOTATIONS_PATH)
-        logger.info("Appended annotation to parquet", path=str(ANNOTATIONS_PATH))
+        )
+        logger.info("Stored annotation")
     except Exception as e:
-        logger.error("Failed to append annotation", error=str(e))
+        logger.error("Failed to store annotation", error=str(e))
 
     return {
         "metta_premise": output.metta_premise,
@@ -686,33 +592,40 @@ def query_annotations(
 
     Returns matching rows as a list of dicts, plus the total count.
     """
-    path_map: dict[str, Path] = {
-        "annotations": ANNOTATIONS_PATH,
-        "validations": VALIDATIONS_PATH,
-        "cleaned": PROJECT_ROOT / "datasets" / "cleaned_annotations.parquet",
-    }
+    valid_files = {"annotations", "validations", "cleaned"}
+    if file not in valid_files:
+        return {"error": f"Unknown file '{file}'. Use: {', '.join(valid_files)}"}
 
-    path = path_map.get(file)
-    if path is None:
-        return {"error": f"Unknown file '{file}'. Use: {', '.join(path_map)}"}
-
-    if not path.exists():
-        return {"error": f"File not found: {path}"}
-
-    try:
-        df = pl.read_parquet(path)
-    except Exception as e:
-        return {"error": f"Failed to read parquet: {e}"}
-
-    if filter_column and filter_value:
-        if filter_column not in df.columns:
-            return {
-                "error": f"Column '{filter_column}' not found. Available: {df.columns}",
-            }
-        df = df.filter(pl.col(filter_column).cast(pl.Utf8) == filter_value)
-
-    total = len(df)
-    rows = df.head(limit).to_dicts()
+    # 'cleaned' still reads from parquet (separate pipeline output)
+    if file == "cleaned":
+        cleaned_path = PROJECT_ROOT / "datasets" / "cleaned_annotations.parquet"
+        if not cleaned_path.exists():
+            return {"error": f"File not found: {cleaned_path}"}
+        try:
+            df = pl.read_parquet(cleaned_path)
+        except Exception as e:
+            return {"error": f"Failed to read parquet: {e}"}
+        if filter_column and filter_value:
+            if filter_column not in df.columns:
+                return {
+                    "error": f"Column '{filter_column}' not found. Available: {df.columns}"
+                }
+            df = df.filter(pl.col(filter_column).cast(pl.Utf8) == filter_value)
+        total = len(df)
+        rows = df.head(limit).to_dicts()
+        columns = df.columns
+    else:
+        result = store.query(
+            table=file,
+            filter_column=filter_column,
+            filter_value=filter_value,
+            limit=limit,
+        )
+        if "error" in result:
+            return result
+        total = result["total"]
+        rows = result["rows"]
+        columns = result["columns"]
 
     # Truncate long string values to keep MCP response size manageable
     max_cell_len = 200
@@ -724,7 +637,7 @@ def query_annotations(
     return {
         "total": total,
         "returned": len(rows),
-        "columns": df.columns,
+        "columns": columns,
         "rows": rows,
     }
 
@@ -752,16 +665,11 @@ def update_annotation(
         validate_expressions_by_label,
     )
 
-    if not ANNOTATIONS_PATH.exists():
-        return {"error": f"Annotations file not found: {ANNOTATIONS_PATH}"}
-
-    df = pl.read_parquet(ANNOTATIONS_PATH)
-    match = df.filter(pl.col("annotation_id") == annotation_id)
-
-    if len(match) == 0:
+    existing = store.get_annotation(annotation_id)
+    if existing is None:
         return {"error": f"Annotation '{annotation_id}' not found."}
 
-    label_str = match["label"][0]
+    label_str = existing.get("label", "")
     # Normalize common typo in source data
     if label_str == "contradication":
         label_str = "contradiction"
@@ -776,41 +684,22 @@ def update_annotation(
         metta_hypothesis=metta_hypothesis.strip(),
     )
 
-    old_version = match["version"][0] or "0.0.0"
+    old_version = existing.get("version") or "0.0.0"
     human_version = (
         old_version if old_version.endswith("-human") else f"{old_version}-human"
     )
 
-    # Ensure fix_reason column exists for older parquet files
-    if "fix_reason" not in df.columns:
-        df = df.with_columns(pl.lit(None).cast(pl.Utf8).alias("fix_reason"))
-
-    df = df.with_columns(
-        [
-            pl.when(pl.col("annotation_id") == annotation_id)
-            .then(pl.lit(metta_premise.strip()))
-            .otherwise(pl.col("metta_premise"))
-            .alias("metta_premise"),
-            pl.when(pl.col("annotation_id") == annotation_id)
-            .then(pl.lit(metta_hypothesis.strip()))
-            .otherwise(pl.col("metta_hypothesis"))
-            .alias("metta_hypothesis"),
-            pl.when(pl.col("annotation_id") == annotation_id)
-            .then(pl.lit(is_valid))
-            .otherwise(pl.col("is_valid"))
-            .alias("is_valid"),
-            pl.when(pl.col("annotation_id") == annotation_id)
-            .then(pl.lit(human_version))
-            .otherwise(pl.col("version"))
-            .alias("version"),
-            pl.when(pl.col("annotation_id") == annotation_id)
-            .then(pl.lit(fix_reason))
-            .otherwise(pl.col("fix_reason"))
-            .alias("fix_reason"),
-        ]
+    store.update_annotation(
+        annotation_id,
+        {
+            "metta_premise": metta_premise.strip(),
+            "metta_hypothesis": metta_hypothesis.strip(),
+            "is_valid": is_valid,
+            "version": human_version,
+            "fix_reason": fix_reason,
+        },
     )
 
-    df.write_parquet(ANNOTATIONS_PATH)
     logger.info(
         "Updated annotation",
         annotation_id=annotation_id,
@@ -819,9 +708,65 @@ def update_annotation(
         fix_reason=fix_reason,
     )
 
-    updated = df.filter(pl.col("annotation_id") == annotation_id).to_dicts()[0]
+    updated = store.get_annotation(annotation_id)
     # Truncate system_prompt for response size
-    if "system_prompt" in updated and isinstance(updated["system_prompt"], str):
+    if (
+        updated
+        and "system_prompt" in updated
+        and isinstance(updated["system_prompt"], str)
+    ):
         updated["system_prompt"] = updated["system_prompt"][:100] + "..."
 
     return {"success": True, "is_valid": is_valid, "annotation": updated}
+
+
+@mcp.tool()
+def export_annotations_parquet(
+    table: str = "annotations",
+) -> dict[str, Any]:
+    """Export the SQLite annotation store to a parquet file.
+
+    Use this to generate parquet files for HuggingFace dataset uploads.
+
+    Args:
+        table: Which table to export — "annotations" or "validations".
+
+    Returns the export path and row count.
+    """
+    path_map = {
+        "annotations": ANNOTATIONS_PATH,
+        "validations": VALIDATIONS_PATH,
+    }
+    path = path_map.get(table)
+    if path is None:
+        return {"error": f"Unknown table '{table}'. Use: {', '.join(path_map)}"}
+
+    try:
+        count = store.export_parquet(path, table=table)
+        return {"success": True, "path": str(path), "rows": count}
+    except Exception as e:
+        return {"success": False, "error": str(e)}
+
+
+@mcp.tool()
+def import_annotations_parquet(
+    path: str | None = None,
+) -> dict[str, Any]:
+    """Import annotations from a parquet file into the SQLite store.
+
+    Use this to migrate existing parquet data into the new SQLite backend.
+
+    Args:
+        path: Path to parquet file. Defaults to the standard annotations.parquet.
+
+    Returns the number of rows imported.
+    """
+    parquet_path = Path(path) if path else ANNOTATIONS_PATH
+    if not parquet_path.exists():
+        return {"error": f"File not found: {parquet_path}"}
+
+    try:
+        count = store.import_parquet(parquet_path, table="annotations")
+        return {"success": True, "rows_imported": count, "source": str(parquet_path)}
+    except Exception as e:
+        return {"success": False, "error": str(e)}

--- a/metta_nl_corpus/services/defs/cleaning/assets.py
+++ b/metta_nl_corpus/services/defs/cleaning/assets.py
@@ -9,7 +9,8 @@ from dagster import AssetExecutionContext, Config, asset
 from huggingface_hub import hf_hub_download
 from structlog import getLogger
 
-from metta_nl_corpus.constants import CLEANED_ANNOTATIONS_PATH
+from metta_nl_corpus.constants import ANNOTATIONS_DB_PATH, CLEANED_ANNOTATIONS_PATH
+from metta_nl_corpus.lib.storage import AnnotationStore
 from metta_nl_corpus.models import RelationKind
 from metta_nl_corpus.services.defs.transformation.assets import (
     get_grounding_space_versions,
@@ -239,7 +240,11 @@ def cleaned_annotations(
         valid_after=after_stats["valid"],
     )
 
-    # Write output
+    # Write cleaned data to SQLite and export parquet
+    cleaned_store = AnnotationStore(ANNOTATIONS_DB_PATH)
+    for row in df.to_dicts():
+        cleaned_store.insert_annotation(row)
+
     CLEANED_ANNOTATIONS_PATH.parent.mkdir(parents=True, exist_ok=True)
     df.write_parquet(CLEANED_ANNOTATIONS_PATH)
 

--- a/metta_nl_corpus/services/defs/transformation/assets.py
+++ b/metta_nl_corpus/services/defs/transformation/assets.py
@@ -24,10 +24,12 @@ from tenacity import retry_if_exception_type, stop_after_attempt, wait_exponenti
 
 from metta_nl_corpus.constants import (
     ANNOTATION_GUIDELINE_PATH,
+    ANNOTATIONS_DB_PATH,
     ANNOTATIONS_PATH,
     PROJECT_ROOT,
     VALIDATIONS_PATH,
 )
+from metta_nl_corpus.lib.storage import AnnotationStore
 from metta_nl_corpus.lib.helpers import (
     cleanup_metta_expression,
     parse_all,
@@ -930,10 +932,17 @@ def data_annotations(
         else new_validations
     )
 
-    # Write to disk
-    all_annotations.write_parquet(ANNOTATIONS_PATH)
+    # Write to SQLite (atomic inserts) and export parquet for compatibility
+    annotation_store = AnnotationStore(ANNOTATIONS_DB_PATH)
+    for row in new_annotations.to_dicts():
+        annotation_store.insert_annotation(row)
+    for row in new_validations.to_dicts():
+        annotation_store.insert_validation(row)
+
+    # Export to parquet for HuggingFace / backward compatibility
+    annotation_store.export_parquet(ANNOTATIONS_PATH, table="annotations")
     if not all_validations.is_empty():
-        all_validations.write_parquet(VALIDATIONS_PATH)
+        annotation_store.export_parquet(VALIDATIONS_PATH, table="validations")
 
     logger.info(
         "Completed data annotation",


### PR DESCRIPTION
## Summary
- Replace parquet read-modify-write pattern with SQLite (WAL mode) for ACID-safe concurrent writes
- Add `AnnotationStore` class in `lib/storage.py` — insert, update, query, export/import
- Replace all 6 parquet write patterns in `mcp_server.py` with atomic `INSERT` statements
- Add `export_annotations_parquet` and `import_annotations_parquet` MCP tools
- Update pipeline assets to write to SQLite alongside parquet exports
- Derive SQLite column definitions automatically from Pandera models

## Context
The annotations parquet file got corrupted by concurrent writes from `asyncio.gather` batch processing. Parquet has zero concurrency protection — every write reads the entire file, appends in memory, and rewrites. SQLite in WAL mode provides full ACID guarantees with single-writer/multi-reader concurrency.