### PR TITLE
Add PLN truth values and contraryAttribute to inference engine

### DIFF
--- a/metta_nl_corpus/services/spaces/inference-tv-example.metta
+++ b/metta_nl_corpus/services/spaces/inference-tv-example.metta
@@ -1,0 +1,55 @@
+;; === PLN Truth Values: Worked Example ===
+;; Demonstrates that truth values coexist with the existing Boolean engine.
+
+!(import! &self inference)
+
+;; === Existing Boolean inference still works ===
+!(add-proposition (white swan))
+!(add-proposition (swan this-swan))
+!(find-evidence-for (white this-swan))
+;; Expected: derives (white this-swan) — no change from before
+
+;; === New: propositions with truth values ===
+;; "Dogs shed fur" — high confidence from veterinary science
+!(add-proposition-tv (shedsFur Dog) (STV 0.97 0.95))
+
+;; "This is a dog" — observed directly, very high confidence
+!(add-proposition-tv (is-a a-dog Dog) (STV 1.0 0.99))
+
+;; === Query truth values ===
+!(get-tv (shedsFur Dog))
+;; Expected: (STV 0.97 0.95)
+
+!(get-tv (is-a a-dog Dog))
+;; Expected: (STV 1.0 0.99)
+
+;; === Boolean inference still works on TV-annotated facts ===
+!(find-evidence-for (shedsFur a-dog))
+;; Expected: derives (shedsFur a-dog) via transitivity
+
+;; === TV-aware inference ===
+!(find-evidence-for-tv (shedsFur Dog))
+;; Expected: (≞ (shedsFur Dog) (STV 0.97 0.95))
+
+;; === Combine truth values (PLN deduction) ===
+!(combine-tv (STV 0.9 0.8) (STV 0.7 0.6))
+;; Expected: (STV 0.63 0.6)  — s = 0.9*0.7, c = min(0.8, 0.6)
+
+;; === Prediction Market Scenario ===
+;; "BTC price above 60k" and "BTC price below 50k" are contrary predicates
+!(add-contrary priceAbove60k priceBelow50k)
+
+;; Market says: BTC above 60k with 70% confidence
+!(add-proposition-tv (priceAbove60k BTC) (STV 0.7 0.6))
+
+;; Another source says: BTC below 50k with 40% confidence
+!(add-proposition-tv (priceBelow50k BTC) (STV 0.4 0.3))
+
+;; This should derive ⊥ (contradiction)
+!(find-evidence-for ⊥)
+;; Expected: derives ⊥ — priceAbove60k and priceBelow50k are contrary
+
+;; === Non-contradictory overlapping ranges ===
+;; "above 60k" and "below 70k" can both be true — no contrary declared
+;; !(add-proposition-tv (priceBelow70k BTC) (STV 0.8 0.5))
+;; Would NOT produce ⊥ because no contraryAttribute relation exists

--- a/metta_nl_corpus/services/spaces/inference.metta
+++ b/metta_nl_corpus/services/spaces/inference.metta
@@ -87,3 +87,36 @@
 
 (= (add-proposition ($rel $ob $sub)) (add-atom &a (=> ($x $ob) ($rel $x $sub))))
 (= (add-proposition ($rel $ob $sub)) (add-atom &a (=> ($x $sub) ($rel $ob $x))))
+
+;; === PLN Truth Values ===
+;; (≞ Proposition (STV strength confidence))
+;;   strength   ∈ [0.0, 1.0] — probability
+;;   confidence ∈ [0.0, 1.0] — weight of evidence
+
+;; add-proposition-tv: adds both the boolean proposition AND its truth value
+(= (add-proposition-tv ($attr $ob) (STV $s $c))
+   (let () (add-proposition ($attr $ob))
+     (let () (add-atom &a (≞ ($attr $ob) (STV $s $c)))
+       (≞ ($attr $ob) (STV $s $c)))))
+
+;; get-tv: retrieve the truth value for a proposition
+(= (get-tv $expr) (match &a (≞ $expr (STV $s $c)) (STV $s $c)))
+
+;; combine-tv: PLN deduction — s = s1 * s2, c = min(c1, c2)
+(= (combine-tv (STV $s1 $c1) (STV $s2 $c2))
+   (STV (* $s1 $s2) (if (< $c1 $c2) $c1 $c2)))
+
+;; find-evidence-for-tv: returns (≞ proposition (STV s c)) if TV exists
+(= (find-evidence-for-tv $expr)
+   (let $ev (find-evidence-for $expr)
+     (let $tv (get-tv $expr)
+       (≞ $ev $tv))))
+
+;; contraryAttribute: two predicates that cannot both hold on the same entity
+(= (add-contrary $a $b)
+   (add-atom &a (contraryAttribute $a $b)))
+
+;; Contradiction rules for contrary attributes
+!(add-proposition (=> (, (contraryAttribute $a $b) ($a $x) ($b $x)) ⊥))
+;; Symmetric
+!(add-proposition (=> (, (contraryAttribute $a $b) ($b $x) ($a $x)) ⊥))

--- a/tests/test_inference_engine.py
+++ b/tests/test_inference_engine.py
@@ -1,9 +1,29 @@
 from pathlib import Path
 
+from hyperon import MeTTa
+
 from metta_nl_corpus.services.defs.transformation.assets import (
     validate_expressions_are_contradictory,
     validate_expressions_are_entailing,
 )
+
+INFERENCE_PATH = (
+    Path(__file__).parent.parent
+    / "metta_nl_corpus"
+    / "services"
+    / "spaces"
+    / "inference.metta"
+)
+
+
+def _run_with_inference(*expressions: str) -> list:
+    """Load inference.metta, run expressions, return last result."""
+    runner = MeTTa()
+    runner.run(INFERENCE_PATH.read_text())
+    result = None
+    for expr in expressions:
+        result = runner.run(expr)
+    return result
 
 
 def test_expression_entails_itself():
@@ -62,3 +82,102 @@ def test_no_contradiction():
     ).read_text()
 
     assert not validate_expressions_are_contradictory("", data, verbose=True)
+
+
+# === PLN Truth Value Tests ===
+
+
+def test_add_proposition_tv_and_get_tv():
+    result = _run_with_inference(
+        "!(add-proposition-tv (shedsFur Dog) (STV 0.97 0.95))",
+        "!(get-tv (shedsFur Dog))",
+    )
+    assert result and len(result[-1]) > 0
+    assert "0.97" in str(result[-1][0])
+    assert "0.95" in str(result[-1][0])
+
+
+def test_boolean_inference_with_tv_propositions():
+    """Transitivity still works on TV-annotated facts."""
+    result = _run_with_inference(
+        "!(add-proposition-tv (shedsFur Dog) (STV 0.97 0.95))",
+        "!(add-proposition-tv (is-a a-dog Dog) (STV 1.0 0.99))",
+        "!(find-evidence-for (shedsFur a-dog))",
+    )
+    assert result and len(result[-1]) > 0
+
+
+def test_combine_tv():
+    result = _run_with_inference(
+        "!(combine-tv (STV 0.9 0.8) (STV 0.7 0.6))",
+    )
+    assert result and len(result[-1]) > 0
+    tv_str = str(result[-1][0])
+    # s = 0.9 * 0.7 = 0.63, c = min(0.8, 0.6) = 0.6
+    assert "0.63" in tv_str or "0.6300" in tv_str
+    assert "0.6" in tv_str
+
+
+def test_find_evidence_for_tv():
+    result = _run_with_inference(
+        "!(add-proposition-tv (shedsFur Dog) (STV 0.97 0.95))",
+        "!(find-evidence-for-tv (shedsFur Dog))",
+    )
+    assert result and len(result[-1]) > 0
+    tv_str = str(result[-1][0])
+    assert "≞" in tv_str
+    assert "0.97" in tv_str
+
+
+def test_contrary_attribute_contradiction():
+    """contraryAttribute triggers ⊥."""
+    result = _run_with_inference(
+        "!(add-contrary priceAbove60k priceBelow50k)",
+        "!(add-proposition (priceAbove60k BTC))",
+        "!(add-proposition (priceBelow50k BTC))",
+        "!(find-evidence-for ⊥)",
+    )
+    assert result and len(result[-1]) > 0
+
+
+def test_contrary_attribute_symmetric():
+    """Contradiction works in reverse order too."""
+    result = _run_with_inference(
+        "!(add-contrary priceAbove60k priceBelow50k)",
+        "!(add-proposition (priceBelow50k BTC))",
+        "!(add-proposition (priceAbove60k BTC))",
+        "!(find-evidence-for ⊥)",
+    )
+    assert result and len(result[-1]) > 0
+
+
+def test_prediction_contradiction():
+    """Full scenario: 'BTC above 60k' vs 'BTC below 50k' with TVs."""
+    result = _run_with_inference(
+        "!(add-contrary priceAbove60k priceBelow50k)",
+        "!(add-proposition-tv (priceAbove60k BTC) (STV 0.7 0.6))",
+        "!(add-proposition-tv (priceBelow50k BTC) (STV 0.4 0.3))",
+        "!(find-evidence-for ⊥)",
+    )
+    assert result and len(result[-1]) > 0
+
+
+def test_prediction_no_contradiction():
+    """Overlapping ranges don't contradict without contraryAttribute."""
+    result = _run_with_inference(
+        "!(add-proposition-tv (priceAbove60k BTC) (STV 0.7 0.6))",
+        "!(add-proposition-tv (priceBelow70k BTC) (STV 0.8 0.5))",
+        "!(find-evidence-for ⊥)",
+    )
+    # No contraryAttribute declared, so no contradiction
+    assert not result or len(result[-1]) == 0
+
+
+def test_prediction_entailment_with_tv():
+    """'BTC above 60k' entails 'BTC above 50k' via transitivity."""
+    result = _run_with_inference(
+        "!(add-proposition-tv (priceAbove60k BTC) (STV 0.7 0.6))",
+        "!(add-proposition (priceAbove50k priceAbove60k))",
+        "!(find-evidence-for (priceAbove50k BTC))",
+    )
+    assert result and len(result[-1]) > 0


### PR DESCRIPTION
- Extend inference.metta with TV-aware functions: add-proposition-tv, get-tv, combine-tv, find-evidence-for-tv
- Add contraryAttribute declaration and symmetric contradiction rules
- Update inference-tv-example.metta with prediction market demo scenario
- Add 9 new tests covering TV operations, contrary attributes, and prediction market scenarios (all 14 tests pass)