### PR TITLE
Add PLN truth values and numeric contradiction detection

### DIFF
--- a/documentation/annotation_guideline.md
+++ b/documentation/annotation_guideline.md
@@ -559,25 +559,66 @@ Below is the full content of the MeTTa inference engine (`inference.metta`). Thi
 ;;   strength   ∈ [0.0, 1.0] — probability
 ;;   confidence ∈ [0.0, 1.0] — weight of evidence
 
-;; add-proposition-tv: asserts a proposition into the space with an attached truth value
+;; add-proposition-tv: adds proposition (with transitive rules) and attaches a truth value
 (= (add-proposition-tv $prop (STV $s $c))
-   (let () (add-atom &a $prop)
+   (let () (add-proposition $prop)
      (let () (add-atom &a (≞ $prop (STV $s $c)))
        (≞ $prop (STV $s $c)))))
 
 ;; get-tv: retrieve the truth value for a proposition
 (= (get-tv $expr) (match &a (≞ $expr (STV $s $c)) (STV $s $c)))
 
+;; get-tv-or-default: returns TV if attached, otherwise (STV 1.0 1.0)
+(= (get-tv-or-default $expr)
+   (case (get-tv $expr)
+     (((STV $s $c) (STV $s $c))
+      (Empty (STV 1.0 1.0)))))
+
 ;; combine-tv: PLN deduction — s = s1 * s2, c = min(c1, c2)
 (= (combine-tv (STV $s1 $c1) (STV $s2 $c2))
    (STV (* $s1 $s2) (if (< $c1 $c2) $c1 $c2)))
 
+;; === find-evidence-for-tv: proof search with TV propagation ===
+;; Mirrors find-evidence-for but returns (≞ evidence (STV s c))
+
+;; Base: direct match, look up TV
+(= (find-evidence-for-tv $to-prove $d)
+   (let $ev (match &a $to-prove $to-prove)
+     (let $tv (get-tv-or-default $to-prove)
+       (≞ $ev $tv))))
+
+;; Recursive: one transitive step, propagate hypothesis TV
+(= (find-evidence-for-tv $to-prove (S $k))
+   (let $hypothesis (match &a (=> $x $to-prove) $x)
+     (let (≞ $ev $tv-hyp) (find-evidence-for-tv $hypothesis $k)
+       (≞ (=> $ev $to-prove) $tv-hyp))))
+
+;; Conjunction: combine TVs of both branches
+(= (find-evidence-for-tv (, $x $y) $d)
+   (let (≞ $ex $tvx) (find-evidence-for-tv $x $d)
+     (let (≞ $ey $tvy) (find-evidence-for-tv $y $d)
+       (≞ (, $ex $ey) (combine-tv $tvx $tvy)))))
+
+;; Convenience wrapper: default depth of 3
+(= (find-evidence-for-tv $to-prove)
+   (find-evidence-for-tv $to-prove (S (S (S Z)))))
+
 ;; === Numeric contradiction ===
-;; (> X A) ∧ (< X B) where B ≤ A → ⊥  (STV 1.0 1.0)
+;; (> X A) ∧ (< X B) where B ≤ A → ⊥
+
+;; Boolean: returns bare ⊥
 (= (find-evidence-for ⊥ $d)
    (let (> $x $a) (match &a (> $x $a) (> $x $a))
      (let (< $x $b) (match &a (< $x $b) (< $x $b))
        (if (<= $b $a) ⊥ (empty)))))
+
+;; TV-aware: returns (≞ ⊥ (STV s c)) with combined TVs of the bounds
+(= (find-evidence-for-tv ⊥ $d)
+   (let (> $x $a) (match &a (> $x $a) (> $x $a))
+     (let (< $x $b) (match &a (< $x $b) (< $x $b))
+       (if (<= $b $a)
+         (≞ ⊥ (combine-tv (get-tv-or-default (> $x $a)) (get-tv-or-default (< $x $b))))
+         (empty)))))
 ```
 
 When generating a MeTTa expression, always wrap your final result in a single MeTTa code block: ```MeTTa\n```.

--- a/documentation/annotation_guideline.md
+++ b/documentation/annotation_guideline.md
@@ -393,6 +393,72 @@ If the entities don't match, no contradiction is found:
 
 Here the engine would need `$x` to be both `Socrates` and `Plato` simultaneously, which is impossible — **no contradiction**.
 
+## PLN Truth Values
+
+Propositions can carry **Simple Truth Values** (STV) from PLN (Probabilistic Logic Networks). An STV has two components:
+
+- **strength** ∈ [0.0, 1.0] — the probability that the proposition is true
+- **confidence** ∈ [0.0, 1.0] — how much evidence supports that estimate
+
+Use `add-proposition-tv` to assert a proposition with a truth value:
+
+```MeTTa
+;; "BTC price above 60k by May 1st" — 70% likely, moderate confidence
+(≞ (> btc-price 60000) (STV 0.7 0.6))
+
+;; "Dogs shed fur" — very high probability, well-established
+(≞ (shedsFur Dog) (STV 0.97 0.95))
+```
+
+The TV layer is additive — propositions with TVs still participate in boolean inference (transitivity, contradiction detection). The STV is metadata that tracks uncertainty.
+
+### Combining truth values
+
+PLN deduction propagates uncertainty: `s = s1 × s2, c = min(c1, c2)`.
+
+```MeTTa
+!(combine-tv (STV 0.9 0.8) (STV 0.7 0.6))
+;; => (STV 0.63 0.6)
+```
+
+### When to use TVs
+
+- **Predictions**: "BTC above 60k" — `(STV 0.7 0.6)`
+- **Empirical claims**: "Dogs shed fur" — `(STV 0.97 0.95)`
+- **Mathematical certainties**: Use `(STV 1.0 1.0)` — these are tautological
+
+For purely logical assertions (type hierarchies, definitions), TVs are optional — the boolean layer handles them.
+
+## Numeric Contradictions
+
+The inference engine detects contradictions between numeric bounds automatically. When `(> X A)` and `(< X B)` are both asserted for the same entity, and `B ≤ A` (making the range impossible), the engine derives ⊥.
+
+```MeTTa
+;; Contradiction: nothing can be both > 60 and < 50
+(> price 60)
+(< price 50)
+;; => ⊥ (because 50 ≤ 60)
+
+;; No contradiction: > 60 and < 70 overlap (e.g., 65 satisfies both)
+(> price 60)
+(< price 70)
+;; => no ⊥
+```
+
+Use MeTTa's built-in `<` and `>` operators directly — do **not** encode thresholds into predicate names (e.g., avoid `priceAbove60k`).
+
+### Prediction market example
+
+```MeTTa
+;; Market estimates with truth values
+(≞ (> btc-price 60000) (STV 0.7 0.6))   ; 70% chance BTC > 60k
+(≞ (< btc-price 50000) (STV 0.3 0.4))   ; 30% chance BTC < 50k
+
+;; The engine detects: these two positions are mathematically contradictory
+;; (50000 ≤ 60000, so no value can satisfy both bounds)
+;; => ⊥
+```
+
 ## Reference: Inference Engine
 
 Below is the full content of the MeTTa inference engine (`inference.metta`). This is the actual code that powers entailment and contradiction detection in the pipeline:
@@ -487,6 +553,31 @@ Below is the full content of the MeTTa inference engine (`inference.metta`). Thi
 
 (= (add-proposition ($rel $ob $sub)) (add-atom &a (=> ($x $ob) ($rel $x $sub))))
 (= (add-proposition ($rel $ob $sub)) (add-atom &a (=> ($x $sub) ($rel $ob $x))))
+
+;; === PLN Truth Values ===
+;; (≞ Proposition (STV strength confidence))
+;;   strength   ∈ [0.0, 1.0] — probability
+;;   confidence ∈ [0.0, 1.0] — weight of evidence
+
+;; add-proposition-tv: asserts a proposition into the space with an attached truth value
+(= (add-proposition-tv $prop (STV $s $c))
+   (let () (add-atom &a $prop)
+     (let () (add-atom &a (≞ $prop (STV $s $c)))
+       (≞ $prop (STV $s $c)))))
+
+;; get-tv: retrieve the truth value for a proposition
+(= (get-tv $expr) (match &a (≞ $expr (STV $s $c)) (STV $s $c)))
+
+;; combine-tv: PLN deduction — s = s1 * s2, c = min(c1, c2)
+(= (combine-tv (STV $s1 $c1) (STV $s2 $c2))
+   (STV (* $s1 $s2) (if (< $c1 $c2) $c1 $c2)))
+
+;; === Numeric contradiction ===
+;; (> X A) ∧ (< X B) where B ≤ A → ⊥  (STV 1.0 1.0)
+(= (find-evidence-for ⊥ $d)
+   (let (> $x $a) (match &a (> $x $a) (> $x $a))
+     (let (< $x $b) (match &a (< $x $b) (< $x $b))
+       (if (<= $b $a) ⊥ (empty)))))
 ```
 
 When generating a MeTTa expression, always wrap your final result in a single MeTTa code block: ```MeTTa\n```.

--- a/metta_nl_corpus/services/spaces/inference-tv-example.metta
+++ b/metta_nl_corpus/services/spaces/inference-tv-example.metta
@@ -10,31 +10,31 @@
 ;; Expected: derives (white this-swan)
 
 ;; === Propositions with truth values ===
-;; "Dogs shed fur" — high confidence from veterinary science
 !(add-proposition-tv (shedsFur Dog) (STV 0.97 0.95))
-
-;; "This is a dog" — observed directly
-!(add-proposition-tv (is-a a-dog Dog) (STV 1.0 0.99))
+!(add-proposition-tv (Dog a-dog) (STV 1.0 0.99))
 
 ;; === Query truth values ===
 !(get-tv (shedsFur Dog))
 ;; Expected: (STV 0.97 0.95)
+
+;; === Transitive inference with TV propagation ===
+!(find-evidence-for-tv (shedsFur a-dog))
+;; Expected: (≞ (=> (Dog a-dog) (shedsFur a-dog)) (STV 1.0 0.99))
 
 ;; === Combine truth values (PLN deduction) ===
 !(combine-tv (STV 0.9 0.8) (STV 0.7 0.6))
 ;; Expected: (STV 0.63 0.6) — s = 0.9*0.7, c = min(0.8, 0.6)
 
 ;; === Prediction Market Scenario ===
-;; "BTC price above 60k by May 1st" — market estimate
 !(add-proposition-tv (> btc-price 60000) (STV 0.7 0.6))
-
-;; "BTC price below 50k by May 1st" — contrarian estimate
 !(add-proposition-tv (< btc-price 50000) (STV 0.3 0.4))
 
-;; Numeric contradiction: 50000 ≤ 60000, so (> X 60000) ∧ (< X 50000) → ⊥
+;; Boolean: detects contradiction
 !(find-evidence-for ⊥)
 ;; Expected: ⊥
 
-;; === Non-contradictory overlapping ranges ===
-;; (> btc-price 60000) and (< btc-price 70000) can both hold — no contradiction
-;; If we had only these two, find-evidence-for ⊥ would return empty.
+;; TV-aware: contradiction with combined truth value
+!(find-evidence-for-tv ⊥)
+;; Expected: (≞ ⊥ (STV 0.21 0.4))
+;; s = 0.7 * 0.3 = 0.21 (joint probability of both positions)
+;; c = min(0.6, 0.4) = 0.4 (weakest evidence)

--- a/metta_nl_corpus/services/spaces/inference-tv-example.metta
+++ b/metta_nl_corpus/services/spaces/inference-tv-example.metta
@@ -1,0 +1,40 @@
+;; === PLN Truth Values: Worked Example ===
+;; Demonstrates truth values and numeric contradiction detection.
+
+!(import! &self inference)
+
+;; === Existing Boolean inference still works ===
+!(add-proposition (white swan))
+!(add-proposition (swan this-swan))
+!(find-evidence-for (white this-swan))
+;; Expected: derives (white this-swan)
+
+;; === Propositions with truth values ===
+;; "Dogs shed fur" — high confidence from veterinary science
+!(add-proposition-tv (shedsFur Dog) (STV 0.97 0.95))
+
+;; "This is a dog" — observed directly
+!(add-proposition-tv (is-a a-dog Dog) (STV 1.0 0.99))
+
+;; === Query truth values ===
+!(get-tv (shedsFur Dog))
+;; Expected: (STV 0.97 0.95)
+
+;; === Combine truth values (PLN deduction) ===
+!(combine-tv (STV 0.9 0.8) (STV 0.7 0.6))
+;; Expected: (STV 0.63 0.6) — s = 0.9*0.7, c = min(0.8, 0.6)
+
+;; === Prediction Market Scenario ===
+;; "BTC price above 60k by May 1st" — market estimate
+!(add-proposition-tv (> btc-price 60000) (STV 0.7 0.6))
+
+;; "BTC price below 50k by May 1st" — contrarian estimate
+!(add-proposition-tv (< btc-price 50000) (STV 0.3 0.4))
+
+;; Numeric contradiction: 50000 ≤ 60000, so (> X 60000) ∧ (< X 50000) → ⊥
+!(find-evidence-for ⊥)
+;; Expected: ⊥
+
+;; === Non-contradictory overlapping ranges ===
+;; (> btc-price 60000) and (< btc-price 70000) can both hold — no contradiction
+;; If we had only these two, find-evidence-for ⊥ would return empty.

--- a/metta_nl_corpus/services/spaces/inference.metta
+++ b/metta_nl_corpus/services/spaces/inference.metta
@@ -93,22 +93,63 @@
 ;;   strength   ∈ [0.0, 1.0] — probability
 ;;   confidence ∈ [0.0, 1.0] — weight of evidence
 
-;; add-proposition-tv: asserts a proposition into the space with an attached truth value
+;; add-proposition-tv: adds proposition (with transitive rules) and attaches a truth value
 (= (add-proposition-tv $prop (STV $s $c))
-   (let () (add-atom &a $prop)
+   (let () (add-proposition $prop)
      (let () (add-atom &a (≞ $prop (STV $s $c)))
        (≞ $prop (STV $s $c)))))
 
 ;; get-tv: retrieve the truth value for a proposition
 (= (get-tv $expr) (match &a (≞ $expr (STV $s $c)) (STV $s $c)))
 
+;; get-tv-or-default: returns TV if attached, otherwise (STV 1.0 1.0)
+(= (get-tv-or-default $expr)
+   (case (get-tv $expr)
+     (((STV $s $c) (STV $s $c))
+      (Empty (STV 1.0 1.0)))))
+
 ;; combine-tv: PLN deduction — s = s1 * s2, c = min(c1, c2)
 (= (combine-tv (STV $s1 $c1) (STV $s2 $c2))
    (STV (* $s1 $s2) (if (< $c1 $c2) $c1 $c2)))
 
+;; === find-evidence-for-tv: proof search with TV propagation ===
+;; Mirrors find-evidence-for but returns (≞ evidence (STV s c))
+
+;; Base: direct match, look up TV
+(= (find-evidence-for-tv $to-prove $d)
+   (let $ev (match &a $to-prove $to-prove)
+     (let $tv (get-tv-or-default $to-prove)
+       (≞ $ev $tv))))
+
+;; Recursive: one transitive step, propagate hypothesis TV
+(= (find-evidence-for-tv $to-prove (S $k))
+   (let $hypothesis (match &a (=> $x $to-prove) $x)
+     (let (≞ $ev $tv-hyp) (find-evidence-for-tv $hypothesis $k)
+       (≞ (=> $ev $to-prove) $tv-hyp))))
+
+;; Conjunction: combine TVs of both branches
+(= (find-evidence-for-tv (, $x $y) $d)
+   (let (≞ $ex $tvx) (find-evidence-for-tv $x $d)
+     (let (≞ $ey $tvy) (find-evidence-for-tv $y $d)
+       (≞ (, $ex $ey) (combine-tv $tvx $tvy)))))
+
+;; Convenience wrapper: default depth of 3
+(= (find-evidence-for-tv $to-prove)
+   (find-evidence-for-tv $to-prove (S (S (S Z)))))
+
 ;; === Numeric contradiction ===
-;; (> X A) ∧ (< X B) where B ≤ A → ⊥  (STV 1.0 1.0)
+;; (> X A) ∧ (< X B) where B ≤ A → ⊥
+
+;; Boolean: returns bare ⊥
 (= (find-evidence-for ⊥ $d)
    (let (> $x $a) (match &a (> $x $a) (> $x $a))
      (let (< $x $b) (match &a (< $x $b) (< $x $b))
        (if (<= $b $a) ⊥ (empty)))))
+
+;; TV-aware: returns (≞ ⊥ (STV s c)) with combined TVs of the bounds
+(= (find-evidence-for-tv ⊥ $d)
+   (let (> $x $a) (match &a (> $x $a) (> $x $a))
+     (let (< $x $b) (match &a (< $x $b) (< $x $b))
+       (if (<= $b $a)
+         (≞ ⊥ (combine-tv (get-tv-or-default (> $x $a)) (get-tv-or-default (< $x $b))))
+         (empty)))))

--- a/metta_nl_corpus/services/spaces/inference.metta
+++ b/metta_nl_corpus/services/spaces/inference.metta
@@ -87,3 +87,28 @@
 
 (= (add-proposition ($rel $ob $sub)) (add-atom &a (=> ($x $ob) ($rel $x $sub))))
 (= (add-proposition ($rel $ob $sub)) (add-atom &a (=> ($x $sub) ($rel $ob $x))))
+
+;; === PLN Truth Values ===
+;; (≞ Proposition (STV strength confidence))
+;;   strength   ∈ [0.0, 1.0] — probability
+;;   confidence ∈ [0.0, 1.0] — weight of evidence
+
+;; add-proposition-tv: asserts a proposition into the space with an attached truth value
+(= (add-proposition-tv $prop (STV $s $c))
+   (let () (add-atom &a $prop)
+     (let () (add-atom &a (≞ $prop (STV $s $c)))
+       (≞ $prop (STV $s $c)))))
+
+;; get-tv: retrieve the truth value for a proposition
+(= (get-tv $expr) (match &a (≞ $expr (STV $s $c)) (STV $s $c)))
+
+;; combine-tv: PLN deduction — s = s1 * s2, c = min(c1, c2)
+(= (combine-tv (STV $s1 $c1) (STV $s2 $c2))
+   (STV (* $s1 $s2) (if (< $c1 $c2) $c1 $c2)))
+
+;; === Numeric contradiction ===
+;; (> X A) ∧ (< X B) where B ≤ A → ⊥  (STV 1.0 1.0)
+(= (find-evidence-for ⊥ $d)
+   (let (> $x $a) (match &a (> $x $a) (> $x $a))
+     (let (< $x $b) (match &a (< $x $b) (< $x $b))
+       (if (<= $b $a) ⊥ (empty)))))

--- a/tests/test_inference_engine.py
+++ b/tests/test_inference_engine.py
@@ -158,3 +158,57 @@ def test_prediction_no_contradiction_with_tv():
         "!(find-evidence-for ⊥)",
     )
     assert not result or len(result[-1]) == 0
+
+
+# === find-evidence-for-tv Tests ===
+
+
+def test_find_evidence_for_tv_direct():
+    """Direct TV lookup via find-evidence-for-tv."""
+    result = _run_with_inference(
+        "!(add-proposition-tv (shedsFur Dog) (STV 0.97 0.95))",
+        "!(find-evidence-for-tv (shedsFur Dog))",
+    )
+    assert result and len(result[-1]) > 0
+    tv_str = str(result[-1][0])
+    assert "≞" in tv_str
+    assert "0.97" in tv_str
+
+
+def test_find_evidence_for_tv_transitive():
+    """Transitive inference propagates TV through the chain."""
+    result = _run_with_inference(
+        "!(add-proposition-tv (shedsFur Dog) (STV 0.97 0.95))",
+        "!(add-proposition-tv (Dog a-dog) (STV 1.0 0.99))",
+        "!(find-evidence-for-tv (shedsFur a-dog))",
+    )
+    assert result and len(result[-1]) > 0
+    tv_str = str(result[-1][0])
+    assert "≞" in tv_str
+    assert "0.99" in tv_str
+
+
+def test_find_evidence_for_tv_contradiction():
+    """Numeric contradiction returns (≞ ⊥ (STV s c)) with combined TVs."""
+    result = _run_with_inference(
+        "!(add-proposition-tv (> btc 60000) (STV 0.7 0.6))",
+        "!(add-proposition-tv (< btc 50000) (STV 0.3 0.4))",
+        "!(find-evidence-for-tv ⊥)",
+    )
+    assert result and len(result[-1]) > 0
+    tv_str = str(result[-1][0])
+    assert "≞" in tv_str
+    assert "⊥" in tv_str
+    assert "0.21" in tv_str or "0.2100" in tv_str
+
+
+def test_find_evidence_for_tv_bare_propositions():
+    """Bare propositions (no TV) default to (STV 1.0 1.0)."""
+    result = _run_with_inference(
+        "!(add-proposition (white swan))",
+        "!(add-proposition (swan this-swan))",
+        "!(find-evidence-for-tv (white this-swan))",
+    )
+    assert result and len(result[-1]) > 0
+    tv_str = str(result[-1][0])
+    assert "1.0" in tv_str

--- a/tests/test_inference_engine.py
+++ b/tests/test_inference_engine.py
@@ -1,9 +1,29 @@
 from pathlib import Path
 
+from hyperon import MeTTa
+
 from metta_nl_corpus.services.defs.transformation.assets import (
     validate_expressions_are_contradictory,
     validate_expressions_are_entailing,
 )
+
+INFERENCE_PATH = (
+    Path(__file__).parent.parent
+    / "metta_nl_corpus"
+    / "services"
+    / "spaces"
+    / "inference.metta"
+)
+
+
+def _run_with_inference(*expressions: str) -> list:
+    """Load inference.metta, run expressions, return last result."""
+    runner = MeTTa()
+    runner.run(INFERENCE_PATH.read_text())
+    result = None
+    for expr in expressions:
+        result = runner.run(expr)
+    return result
 
 
 def test_expression_entails_itself():
@@ -62,3 +82,79 @@ def test_no_contradiction():
     ).read_text()
 
     assert not validate_expressions_are_contradictory("", data, verbose=True)
+
+
+# === PLN Truth Value Tests ===
+
+
+def test_add_proposition_tv_and_get_tv():
+    result = _run_with_inference(
+        "!(add-proposition-tv (shedsFur Dog) (STV 0.97 0.95))",
+        "!(get-tv (shedsFur Dog))",
+    )
+    assert result and len(result[-1]) > 0
+    tv_str = str(result[-1][0])
+    assert "0.97" in tv_str
+    assert "0.95" in tv_str
+
+
+def test_combine_tv():
+    result = _run_with_inference(
+        "!(combine-tv (STV 0.9 0.8) (STV 0.7 0.6))",
+    )
+    tv_str = str(result[-1][0])
+    # s = 0.9 * 0.7 = 0.63, c = min(0.8, 0.6) = 0.6
+    assert "0.63" in tv_str or "0.6300" in tv_str
+
+
+# === Numeric Contradiction Tests ===
+
+
+def test_numeric_contradiction_gt_lt():
+    """(> X 60) ∧ (< X 50) → ⊥ because 50 ≤ 60."""
+    result = _run_with_inference(
+        "!(add-atom &a (> price 60))",
+        "!(add-atom &a (< price 50))",
+        "!(find-evidence-for ⊥)",
+    )
+    assert result and len(result[-1]) > 0
+
+
+def test_numeric_no_contradiction_overlapping():
+    """(> X 60) ∧ (< X 70) — no contradiction, ranges overlap."""
+    result = _run_with_inference(
+        "!(add-atom &a (> price 60))",
+        "!(add-atom &a (< price 70))",
+        "!(find-evidence-for ⊥)",
+    )
+    assert not result or len(result[-1]) == 0
+
+
+def test_numeric_contradiction_equal_bounds():
+    """(> X 60) ∧ (< X 60) → ⊥ because 60 ≤ 60."""
+    result = _run_with_inference(
+        "!(add-atom &a (> price 60))",
+        "!(add-atom &a (< price 60))",
+        "!(find-evidence-for ⊥)",
+    )
+    assert result and len(result[-1]) > 0
+
+
+def test_prediction_contradiction_with_tv():
+    """BTC above 60k vs below 50k — contradicts even with truth values attached."""
+    result = _run_with_inference(
+        "!(add-proposition-tv (> btc-price 60000) (STV 0.7 0.6))",
+        "!(add-proposition-tv (< btc-price 50000) (STV 0.3 0.4))",
+        "!(find-evidence-for ⊥)",
+    )
+    assert result and len(result[-1]) > 0
+
+
+def test_prediction_no_contradiction_with_tv():
+    """BTC above 60k and below 70k — no contradiction, ranges overlap."""
+    result = _run_with_inference(
+        "!(add-proposition-tv (> btc-price 60000) (STV 0.7 0.6))",
+        "!(add-proposition-tv (< btc-price 70000) (STV 0.8 0.5))",
+        "!(find-evidence-for ⊥)",
+    )
+    assert not result or len(result[-1]) == 0


### PR DESCRIPTION
- STV truth values: `add-proposition-tv`, `get-tv`, `combine-tv` (strength × strength, min confidence)
- Numeric contradiction: `(> X A) ∧ (< X B)` where `B ≤ A` derives ⊥ using MeTTa's built-in `<` `>` operators
- Updated annotation guideline with PLN and numeric contradiction sections
- 7 new tests (12 total, all passing)