### PR TITLE
Remove special-cased find-evidence-for-tv ⊥ clause

### DIFF
--- a/documentation/annotation_guideline.md
+++ b/documentation/annotation_guideline.md
@@ -605,20 +605,10 @@ Below is the full content of the MeTTa inference engine (`inference.metta`). Thi
 
 ;; === Numeric contradiction ===
 ;; (> X A) ∧ (< X B) where B ≤ A → ⊥
-
-;; Boolean: returns bare ⊥
 (= (find-evidence-for ⊥ $d)
    (let (> $x $a) (match &a (> $x $a) (> $x $a))
      (let (< $x $b) (match &a (< $x $b) (< $x $b))
        (if (<= $b $a) ⊥ (empty)))))
-
-;; TV-aware: returns (≞ ⊥ (STV s c)) with combined TVs of the bounds
-(= (find-evidence-for-tv ⊥ $d)
-   (let (> $x $a) (match &a (> $x $a) (> $x $a))
-     (let (< $x $b) (match &a (< $x $b) (< $x $b))
-       (if (<= $b $a)
-         (≞ ⊥ (combine-tv (get-tv-or-default (> $x $a)) (get-tv-or-default (< $x $b))))
-         (empty)))))
 ```
 
 When generating a MeTTa expression, always wrap your final result in a single MeTTa code block: ```MeTTa\n```.

--- a/metta_nl_corpus/services/spaces/inference-tv-example.metta
+++ b/metta_nl_corpus/services/spaces/inference-tv-example.metta
@@ -29,12 +29,6 @@
 !(add-proposition-tv (> btc-price 60000) (STV 0.7 0.6))
 !(add-proposition-tv (< btc-price 50000) (STV 0.3 0.4))
 
-;; Boolean: detects contradiction
+;; Numeric contradiction: 50000 ≤ 60000, so these bounds are impossible
 !(find-evidence-for ⊥)
 ;; Expected: ⊥
-
-;; TV-aware: contradiction with combined truth value
-!(find-evidence-for-tv ⊥)
-;; Expected: (≞ ⊥ (STV 0.21 0.4))
-;; s = 0.7 * 0.3 = 0.21 (joint probability of both positions)
-;; c = min(0.6, 0.4) = 0.4 (weakest evidence)

--- a/metta_nl_corpus/services/spaces/inference.metta
+++ b/metta_nl_corpus/services/spaces/inference.metta
@@ -139,17 +139,7 @@
 
 ;; === Numeric contradiction ===
 ;; (> X A) ∧ (< X B) where B ≤ A → ⊥
-
-;; Boolean: returns bare ⊥
 (= (find-evidence-for ⊥ $d)
    (let (> $x $a) (match &a (> $x $a) (> $x $a))
      (let (< $x $b) (match &a (< $x $b) (< $x $b))
        (if (<= $b $a) ⊥ (empty)))))
-
-;; TV-aware: returns (≞ ⊥ (STV s c)) with combined TVs of the bounds
-(= (find-evidence-for-tv ⊥ $d)
-   (let (> $x $a) (match &a (> $x $a) (> $x $a))
-     (let (< $x $b) (match &a (< $x $b) (< $x $b))
-       (if (<= $b $a)
-         (≞ ⊥ (combine-tv (get-tv-or-default (> $x $a)) (get-tv-or-default (< $x $b))))
-         (empty)))))

--- a/tests/test_inference_engine.py
+++ b/tests/test_inference_engine.py
@@ -188,20 +188,6 @@ def test_find_evidence_for_tv_transitive():
     assert "0.99" in tv_str
 
 
-def test_find_evidence_for_tv_contradiction():
-    """Numeric contradiction returns (≞ ⊥ (STV s c)) with combined TVs."""
-    result = _run_with_inference(
-        "!(add-proposition-tv (> btc 60000) (STV 0.7 0.6))",
-        "!(add-proposition-tv (< btc 50000) (STV 0.3 0.4))",
-        "!(find-evidence-for-tv ⊥)",
-    )
-    assert result and len(result[-1]) > 0
-    tv_str = str(result[-1][0])
-    assert "≞" in tv_str
-    assert "⊥" in tv_str
-    assert "0.21" in tv_str or "0.2100" in tv_str
-
-
 def test_find_evidence_for_tv_bare_propositions():
     """Bare propositions (no TV) default to (STV 1.0 1.0)."""
     result = _run_with_inference(


### PR DESCRIPTION
find-evidence-for-tv is purely deductive — base, recursive, conjunction. No symbol gets privileged treatment.