### PR TITLE
Unify boolean and TV proof search

### DIFF
--- a/metta_nl_corpus/services/spaces/inference.metta
+++ b/metta_nl_corpus/services/spaces/inference.metta
@@ -24,27 +24,12 @@
 (= (all $expr) (match &a $expr $expr))
 (= (all $expr $out) (match &a $expr $out))
 
-;; 3. find proofs for $to-prove (depth-bounded)
-;; Base: direct match at any depth
-(= (find-evidence-for $to-prove $d) (match &a $to-prove $to-prove))
-
-;; Recursive: one step of transitive chaining (requires depth > 0)
-(= (find-evidence-for $to-prove (S $k)) (=>
-  (let $hypothesis (match &a (=> $x $to-prove) $x)
-      (find-evidence-for $hypothesis $k)
-  )
-  $to-prove
-))
-
-;; Conjunction
-(= (find-evidence-for (, $x $y) $d) (, (find-evidence-for $x $d) (find-evidence-for $y $d)))
-
-;; Disjunction: (or A B) holds if either A or B holds
-(= (find-evidence-for (or $a $b) $d) (find-evidence-for $a $d))
-(= (find-evidence-for (or $a $b) $d) (find-evidence-for $b $d))
-
-;; Convenience wrapper: default depth of 3
-(= (find-evidence-for $to-prove) (find-evidence-for $to-prove (S (S (S Z)))))
+;; 3. find-evidence-for: boolean wrapper around find-evidence-for-tv
+;; Returns evidence only when strength > 0 (i.e. the proof is valid).
+;; All proof logic lives in find-evidence-for-tv below.
+(= (find-evidence-for $to-prove)
+   (let (≞ $ev (STV $s $c)) (find-evidence-for-tv $to-prove)
+     (if (> $s 0.0) $ev (empty))))
 
 
 ;; 4. adding propositions (universal quantification)
@@ -135,6 +120,10 @@
    (let (≞ $ex $tvx) (find-evidence-for-tv $x $d)
      (let (≞ $ey $tvy) (find-evidence-for-tv $y $d)
        (≞ (, $ex $ey) (combine-tv $tvx $tvy)))))
+
+;; Disjunction: (or A B) holds if either A or B holds
+(= (find-evidence-for-tv (or $a $b) $d) (find-evidence-for-tv $a $d))
+(= (find-evidence-for-tv (or $a $b) $d) (find-evidence-for-tv $b $d))
 
 ;; Convenience wrapper: default depth of 3
 (= (find-evidence-for-tv $to-prove)

--- a/tests/test_inference_engine.py
+++ b/tests/test_inference_engine.py
@@ -124,31 +124,31 @@ def _assert_contradiction_tv(result, expected_nonzero=True):
 def test_numeric_contradiction_gt_lt():
     """(> X 60) ∧ (< X 50) → ⊥ because 50 ≤ 60."""
     result = _run_with_inference(
-        "!(add-proposition-tv (> price 60) (STV 0.9 0.9))",
-        "!(add-proposition-tv (< price 50) (STV 0.9 0.9))",
-        "!(find-evidence-for-tv ⊥)",
+        "!(add-atom &a (> price 60))",
+        "!(add-atom &a (< price 50))",
+        "!(find-evidence-for ⊥)",
     )
-    _assert_contradiction_tv(result, expected_nonzero=True)
+    assert result and len(result[-1]) > 0
 
 
 def test_numeric_no_contradiction_overlapping():
-    """(> X 60) ∧ (< X 70) — TV is (STV 0.0 0.0) because ranges overlap."""
+    """(> X 60) ∧ (< X 70) — no contradiction because ranges overlap."""
     result = _run_with_inference(
-        "!(add-proposition-tv (> price 60) (STV 0.9 0.9))",
-        "!(add-proposition-tv (< price 70) (STV 0.9 0.9))",
-        "!(find-evidence-for-tv ⊥)",
+        "!(add-atom &a (> price 60))",
+        "!(add-atom &a (< price 70))",
+        "!(find-evidence-for ⊥)",
     )
-    _assert_contradiction_tv(result, expected_nonzero=False)
+    assert result and len(result[-1]) == 0
 
 
 def test_numeric_contradiction_equal_bounds():
     """(> X 60) ∧ (< X 60) → ⊥ because 60 ≤ 60."""
     result = _run_with_inference(
-        "!(add-proposition-tv (> price 60) (STV 0.9 0.9))",
-        "!(add-proposition-tv (< price 60) (STV 0.9 0.9))",
-        "!(find-evidence-for-tv ⊥)",
+        "!(add-atom &a (> price 60))",
+        "!(add-atom &a (< price 60))",
+        "!(find-evidence-for ⊥)",
     )
-    _assert_contradiction_tv(result, expected_nonzero=True)
+    assert result and len(result[-1]) > 0
 
 
 def test_prediction_contradiction_with_tv():
@@ -241,51 +241,51 @@ def test_find_evidence_for_tv_no_numeric_contradiction():
 def test_gt_lte_contradiction():
     """(> X 6) ∧ (<= X 5) → ⊥ because 5 ≤ 6."""
     result = _run_with_inference(
-        "!(add-proposition-tv (> price 6) (STV 0.9 0.9))",
-        "!(add-proposition-tv (<= price 5) (STV 0.9 0.9))",
-        "!(find-evidence-for-tv ⊥)",
+        "!(add-atom &a (> price 6))",
+        "!(add-atom &a (<= price 5))",
+        "!(find-evidence-for ⊥)",
     )
-    _assert_contradiction_tv(result, expected_nonzero=True)
+    assert result and len(result[-1]) > 0
 
 
 def test_gte_lt_contradiction():
     """(>= X 6) ∧ (< X 5) → ⊥ because 5 ≤ 6."""
     result = _run_with_inference(
-        "!(add-proposition-tv (>= price 6) (STV 0.9 0.9))",
-        "!(add-proposition-tv (< price 5) (STV 0.9 0.9))",
-        "!(find-evidence-for-tv ⊥)",
+        "!(add-atom &a (>= price 6))",
+        "!(add-atom &a (< price 5))",
+        "!(find-evidence-for ⊥)",
     )
-    _assert_contradiction_tv(result, expected_nonzero=True)
+    assert result and len(result[-1]) > 0
 
 
 def test_gte_lte_contradiction():
     """(>= X 6) ∧ (<= X 4) → ⊥ because 4 < 6."""
     result = _run_with_inference(
-        "!(add-proposition-tv (>= price 6) (STV 0.9 0.9))",
-        "!(add-proposition-tv (<= price 4) (STV 0.9 0.9))",
-        "!(find-evidence-for-tv ⊥)",
+        "!(add-atom &a (>= price 6))",
+        "!(add-atom &a (<= price 4))",
+        "!(find-evidence-for ⊥)",
     )
-    _assert_contradiction_tv(result, expected_nonzero=True)
+    assert result and len(result[-1]) > 0
 
 
 def test_gte_lte_no_contradiction_at_equal():
     """(>= X 6) ∧ (<= X 6) — NOT contradiction, X=6 works."""
     result = _run_with_inference(
-        "!(add-proposition-tv (>= price 6) (STV 0.9 0.9))",
-        "!(add-proposition-tv (<= price 6) (STV 0.9 0.9))",
-        "!(find-evidence-for-tv ⊥)",
+        "!(add-atom &a (>= price 6))",
+        "!(add-atom &a (<= price 6))",
+        "!(find-evidence-for ⊥)",
     )
-    _assert_contradiction_tv(result, expected_nonzero=False)
+    assert result and len(result[-1]) == 0
 
 
 def test_lte_gt_cross_bound_contradiction():
     """(<= X 5) ∧ (> X 6) → ⊥ because 5 ≤ 6."""
     result = _run_with_inference(
-        "!(add-proposition-tv (<= price 5) (STV 0.9 0.9))",
-        "!(add-proposition-tv (> price 6) (STV 0.9 0.9))",
-        "!(find-evidence-for-tv ⊥)",
+        "!(add-atom &a (<= price 5))",
+        "!(add-atom &a (> price 6))",
+        "!(find-evidence-for ⊥)",
     )
-    _assert_contradiction_tv(result, expected_nonzero=True)
+    assert result and len(result[-1]) > 0
 
 
 # === Complement TV Tests ===

--- a/tests/test_inference_engine.py
+++ b/tests/test_inference_engine.py
@@ -110,14 +110,25 @@ def test_combine_tv():
 # === Numeric Contradiction Tests ===
 
 
+def _assert_contradiction_tv(result, expected_nonzero=True):
+    """Check that find-evidence-for-tv ⊥ returns meaningful STV."""
+    assert result and len(result[-1]) > 0
+    tv_str = str(result[-1][0])
+    assert "≞" in tv_str
+    if expected_nonzero:
+        assert "(STV 0.0 0.0)" not in tv_str
+    else:
+        assert "(STV 0.0 0.0)" in tv_str
+
+
 def test_numeric_contradiction_gt_lt():
     """(> X 60) ∧ (< X 50) → ⊥ because 50 ≤ 60."""
     result = _run_with_inference(
-        "!(add-atom &a (> price 60))",
-        "!(add-atom &a (< price 50))",
-        "!(find-evidence-for ⊥)",
+        "!(add-proposition-tv (> price 60) (STV 0.9 0.9))",
+        "!(add-proposition-tv (< price 50) (STV 0.9 0.9))",
+        "!(find-evidence-for-tv ⊥)",
     )
-    assert result and len(result[-1]) > 0
+    _assert_contradiction_tv(result, expected_nonzero=True)
 
 
 def test_numeric_no_contradiction_overlapping():
@@ -127,28 +138,27 @@ def test_numeric_no_contradiction_overlapping():
         "!(add-proposition-tv (< price 70) (STV 0.9 0.9))",
         "!(find-evidence-for-tv ⊥)",
     )
-    assert result and len(result[-1]) > 0
-    assert "(STV 0.0 0.0)" in str(result[-1][0])
+    _assert_contradiction_tv(result, expected_nonzero=False)
 
 
 def test_numeric_contradiction_equal_bounds():
     """(> X 60) ∧ (< X 60) → ⊥ because 60 ≤ 60."""
     result = _run_with_inference(
-        "!(add-atom &a (> price 60))",
-        "!(add-atom &a (< price 60))",
-        "!(find-evidence-for ⊥)",
+        "!(add-proposition-tv (> price 60) (STV 0.9 0.9))",
+        "!(add-proposition-tv (< price 60) (STV 0.9 0.9))",
+        "!(find-evidence-for-tv ⊥)",
     )
-    assert result and len(result[-1]) > 0
+    _assert_contradiction_tv(result, expected_nonzero=True)
 
 
 def test_prediction_contradiction_with_tv():
-    """BTC above 60k vs below 50k — contradicts even with truth values attached."""
+    """BTC above 60k vs below 50k — contradiction with combined TVs."""
     result = _run_with_inference(
         "!(add-proposition-tv (> btc-price 60000) (STV 0.7 0.6))",
         "!(add-proposition-tv (< btc-price 50000) (STV 0.3 0.4))",
-        "!(find-evidence-for ⊥)",
+        "!(find-evidence-for-tv ⊥)",
     )
-    assert result and len(result[-1]) > 0
+    _assert_contradiction_tv(result, expected_nonzero=True)
 
 
 def test_prediction_no_contradiction_with_tv():
@@ -158,8 +168,7 @@ def test_prediction_no_contradiction_with_tv():
         "!(add-proposition-tv (< btc-price 70000) (STV 0.8 0.5))",
         "!(find-evidence-for-tv ⊥)",
     )
-    assert result and len(result[-1]) > 0
-    assert "(STV 0.0 0.0)" in str(result[-1][0])
+    _assert_contradiction_tv(result, expected_nonzero=False)
 
 
 # === find-evidence-for-tv Tests ===
@@ -232,60 +241,51 @@ def test_find_evidence_for_tv_no_numeric_contradiction():
 def test_gt_lte_contradiction():
     """(> X 6) ∧ (<= X 5) → ⊥ because 5 ≤ 6."""
     result = _run_with_inference(
-        "!(add-atom &a (> price 6))",
-        "!(add-atom &a (<= price 5))",
-        "!(find-evidence-for ⊥)",
+        "!(add-proposition-tv (> price 6) (STV 0.9 0.9))",
+        "!(add-proposition-tv (<= price 5) (STV 0.9 0.9))",
+        "!(find-evidence-for-tv ⊥)",
     )
-    assert result and len(result[-1]) > 0
+    _assert_contradiction_tv(result, expected_nonzero=True)
 
 
 def test_gte_lt_contradiction():
     """(>= X 6) ∧ (< X 5) → ⊥ because 5 ≤ 6."""
     result = _run_with_inference(
-        "!(add-atom &a (>= price 6))",
-        "!(add-atom &a (< price 5))",
-        "!(find-evidence-for ⊥)",
+        "!(add-proposition-tv (>= price 6) (STV 0.9 0.9))",
+        "!(add-proposition-tv (< price 5) (STV 0.9 0.9))",
+        "!(find-evidence-for-tv ⊥)",
     )
-    assert result and len(result[-1]) > 0
+    _assert_contradiction_tv(result, expected_nonzero=True)
 
 
 def test_gte_lte_contradiction():
     """(>= X 6) ∧ (<= X 4) → ⊥ because 4 < 6."""
     result = _run_with_inference(
-        "!(add-atom &a (>= price 6))",
-        "!(add-atom &a (<= price 4))",
-        "!(find-evidence-for ⊥)",
+        "!(add-proposition-tv (>= price 6) (STV 0.9 0.9))",
+        "!(add-proposition-tv (<= price 4) (STV 0.9 0.9))",
+        "!(find-evidence-for-tv ⊥)",
     )
-    assert result and len(result[-1]) > 0
+    _assert_contradiction_tv(result, expected_nonzero=True)
 
 
 def test_gte_lte_no_contradiction_at_equal():
     """(>= X 6) ∧ (<= X 6) — NOT contradiction, X=6 works."""
-    _run_with_inference(
-        "!(add-atom &a (>= price 6))",
-        "!(add-atom &a (<= price 6))",
-        "!(find-evidence-for ⊥)",
-    )
-    # Boolean engine may find a proof via transitive path, but
-    # find-evidence-for-tv would give (STV 0.0 0.0). Check boolean
-    # computational clause specifically:
-    result2 = _run_with_inference(
+    result = _run_with_inference(
         "!(add-proposition-tv (>= price 6) (STV 0.9 0.9))",
         "!(add-proposition-tv (<= price 6) (STV 0.9 0.9))",
         "!(find-evidence-for-tv ⊥)",
     )
-    assert result2 and len(result2[-1]) > 0
-    assert "(STV 0.0 0.0)" in str(result2[-1][0])
+    _assert_contradiction_tv(result, expected_nonzero=False)
 
 
 def test_lte_gt_cross_bound_contradiction():
     """(<= X 5) ∧ (> X 6) → ⊥ because 5 ≤ 6."""
     result = _run_with_inference(
-        "!(add-atom &a (<= price 5))",
-        "!(add-atom &a (> price 6))",
-        "!(find-evidence-for ⊥)",
+        "!(add-proposition-tv (<= price 5) (STV 0.9 0.9))",
+        "!(add-proposition-tv (> price 6) (STV 0.9 0.9))",
+        "!(find-evidence-for-tv ⊥)",
     )
-    assert result and len(result[-1]) > 0
+    _assert_contradiction_tv(result, expected_nonzero=True)
 
 
 # === Complement TV Tests ===


### PR DESCRIPTION
## Summary
- `find-evidence-for` is now a thin wrapper around `find-evidence-for-tv` that filters on `strength > 0`
- Fixes boolean path returning false positives for numeric non-contradictions
- All proof logic lives in the TV path only — no duplication
- Boolean tests now properly assert `len == 0` for non-contradictions