### PR TITLE
Clean up version and label fields in annotation storage

### DIFF
--- a/metta_nl_corpus/http_server.py
+++ b/metta_nl_corpus/http_server.py
@@ -61,7 +61,7 @@ class BatchAnnotateRequest(BaseModel):
 
 
 async def _annotate_title(title: str, model: str) -> AnnotateResponse:
-    """Run the MeTTa agent on a single title (ontology label)."""
+    """Run the MeTTa agent on a single title (expression label)."""
     from metta_nl_corpus.services.defs.transformation.assets import (
         ExpressionDeps,
         _create_metta_agent,
@@ -73,13 +73,13 @@ async def _annotate_title(title: str, model: str) -> AnnotateResponse:
     deps = ExpressionDeps(
         premise=title,
         hypothesis="",
-        label=RelationKind.ONTOLOGY,
+        label=RelationKind.EXPRESSION,
     )
     last_generation_attempt.set(None)
 
     try:
         result = await agent.run(
-            f"Generate MeTTa ontology expressions for: {title}",
+            f"Generate MeTTa expressions for: {title}",
             deps=deps,
         )
     except Exception as exc:
@@ -108,14 +108,14 @@ async def _annotate_title(title: str, model: str) -> AnnotateResponse:
                 "index": 0,
                 "premise": title,
                 "hypothesis": None,
-                "label": RelationKind.ONTOLOGY.value,
+                "label": RelationKind.EXPRESSION.value,
                 "metta_premise": metta_expressions.strip()
                 if metta_expressions
                 else None,
                 "metta_hypothesis": None,
                 "generation_model": model,
                 "system_prompt": system_prompt,
-                "version": "0.0.3",
+                "version": "0.0.4",
                 "is_valid": is_valid,
                 "input_tokens": input_tokens,
                 "output_tokens": output_tokens,

--- a/metta_nl_corpus/mcp_server.py
+++ b/metta_nl_corpus/mcp_server.py
@@ -39,7 +39,7 @@ mcp = FastMCP(
         "MeTTa-NL-Corpus pipeline server. "
         "Provides tools for parsing MeTTa expressions, validating logical relations, "
         "generating NL-to-MeTTa annotations via an internal AI agent, "
-        "running batch pipelines, querying stored results, and extracting ontologies "
+        "running batch pipelines, querying stored results, and extracting expressions "
         "from natural language sentences via add_expressions."
     ),
 )
@@ -114,9 +114,9 @@ def add_expressions(
     metta_expressions: str,
     model: str = "claude",
 ) -> dict[str, Any]:
-    """Append validated MeTTa ontology expressions to the annotations cache.
+    """Append validated MeTTa expressions to the annotations cache.
 
-    Parses the expressions, creates an annotation row with label="ontology",
+    Parses the expressions, creates an annotation row with label="expression",
     and appends it to the annotations parquet file.
 
     Args:
@@ -144,19 +144,19 @@ def add_expressions(
                 "index": 0,
                 "premise": sentence,
                 "hypothesis": None,
-                "label": RelationKind.ONTOLOGY.value,
+                "label": RelationKind.EXPRESSION.value,
                 "metta_premise": metta_expressions.strip(),
                 "metta_hypothesis": None,
                 "generation_model": model,
                 "system_prompt": system_prompt,
-                "version": "0.0.3",
+                "version": "0.0.4",
                 "is_valid": True,
                 "input_tokens": None,
                 "output_tokens": None,
             }
         )
         logger.info(
-            "Stored ontology annotation",
+            "Stored expression annotation",
             annotation_id=annotation_id,
         )
     except Exception as e:
@@ -201,7 +201,7 @@ def execute_metta(
         metta_code: MeTTa source code to execute.
         premise: Optional natural-language premise. When provided, the code
             and results are stored to the annotations parquet as a
-            human-annotated ontology entry (version v0.0.4-human).
+            human-annotated expression entry (version 0.0.4).
 
     Returns dict with ``results`` (list of result strings) or ``error``.
     """
@@ -230,12 +230,12 @@ def execute_metta(
                     "index": 0,
                     "premise": premise,
                     "hypothesis": None,
-                    "label": RelationKind.ONTOLOGY.value,
+                    "label": RelationKind.EXPRESSION.value,
                     "metta_premise": metta_code.strip(),
                     "metta_hypothesis": None,
                     "generation_model": "claude-opus-4-6",
                     "system_prompt": system_prompt,
-                    "version": "v0.0.4-human",
+                    "version": "0.0.4",
                     "is_valid": True,
                     "input_tokens": None,
                     "output_tokens": None,
@@ -314,7 +314,7 @@ def validate_relation(
                 "metta_hypothesis": metta_hypothesis.strip(),
                 "generation_model": model,
                 "system_prompt": system_prompt,
-                "version": "0.0.3",
+                "version": "0.0.4",
                 "is_valid": is_valid,
                 "input_tokens": None,
                 "output_tokens": None,
@@ -415,7 +415,7 @@ async def ask_metta_agent(
                 "metta_hypothesis": output.metta_hypothesis,
                 "generation_model": model,
                 "system_prompt": system_prompt,
-                "version": "0.0.3",
+                "version": "0.0.4",
                 "is_valid": is_valid,
                 "input_tokens": input_tokens,
                 "output_tokens": output_tokens,
@@ -684,18 +684,12 @@ def update_annotation(
         metta_hypothesis=metta_hypothesis.strip(),
     )
 
-    old_version = existing.get("version") or "0.0.0"
-    human_version = (
-        old_version if old_version.endswith("-human") else f"{old_version}-human"
-    )
-
     store.update_annotation(
         annotation_id,
         {
             "metta_premise": metta_premise.strip(),
             "metta_hypothesis": metta_hypothesis.strip(),
             "is_valid": is_valid,
-            "version": human_version,
             "fix_reason": fix_reason,
         },
     )
@@ -704,7 +698,6 @@ def update_annotation(
         "Updated annotation",
         annotation_id=annotation_id,
         is_valid=is_valid,
-        version=human_version,
         fix_reason=fix_reason,
     )
 

--- a/metta_nl_corpus/models/__init__.py
+++ b/metta_nl_corpus/models/__init__.py
@@ -5,7 +5,7 @@ from pandera.polars import DataFrameModel, Field
 from pandera.typing.common import UInt32
 from pandera.typing.polars import DataFrame
 
-DATA_VERSION = "0.0.1"
+DATA_VERSION = "0.0.5"
 
 
 class TrainingBase(DataFrameModel):
@@ -66,7 +66,7 @@ class RelationKind(StrEnum):
     ENTAILMENT = "entailment"
     NEUTRAL = "neutral"
     CONTRADICTION = "contradiction"
-    ONTOLOGY = "ontology"
+    EXPRESSION = "expression"
     NO_LABEL = "no_label"
 
 


### PR DESCRIPTION
- Rename `RelationKind.ONTOLOGY` to `EXPRESSION`
- Standardize MCP/HTTP server versions to `0.0.4`
- Bump batch pipeline `DATA_VERSION` to `0.0.5`
- Remove `-human` suffix logic from `update_annotation`