### PR TITLE
Add clean_annotation tool with modification tracking

### DIFF
--- a/metta_nl_corpus/lib/storage.py
+++ b/metta_nl_corpus/lib/storage.py
@@ -93,6 +93,21 @@ class AnnotationStore:
         cols_v = ", ".join(f"{name} {typ}" for name, typ in _VALIDATIONS_COLUMNS)
         conn.execute(f"CREATE TABLE IF NOT EXISTS validations ({cols_v})")
         conn.commit()
+        self._migrate_columns(conn)
+
+    def _migrate_columns(self, conn: sqlite3.Connection) -> None:
+        """Add any missing columns to existing tables."""
+        cur = conn.execute("PRAGMA table_info(annotations)")
+        existing = {row[1] for row in cur.fetchall()}
+        for col_name, col_def in _ANNOTATIONS_COLUMNS:
+            if col_name not in existing:
+                # Strip NOT NULL for migration safety — existing rows will be NULL.
+                safe_def = col_def.replace(" NOT NULL", "")
+                conn.execute(
+                    f"ALTER TABLE annotations ADD COLUMN {col_name} {safe_def}"
+                )
+                logger.info("Migrated column", table="annotations", column=col_name)
+        conn.commit()
 
     # -- annotations -----------------------------------------------------------
 

--- a/metta_nl_corpus/mcp_server.py
+++ b/metta_nl_corpus/mcp_server.py
@@ -714,6 +714,93 @@ def update_annotation(
 
 
 @mcp.tool()
+def clean_annotation(
+    annotation_id: str,
+    metta_premise: str | None = None,
+    metta_hypothesis: str | None = None,
+    comment: str | None = None,
+) -> dict[str, Any]:
+    """Fix and re-validate a single annotation.
+
+    Allows patching either metta_premise, metta_hypothesis, or both.
+    Unchanged fields keep their current value. Re-validates after patching
+    and records modification_date and modification_comment.
+
+    Args:
+        annotation_id: The UUID of the annotation to clean.
+        metta_premise: New MeTTa premise (or None to keep existing).
+        metta_hypothesis: New MeTTa hypothesis (or None to keep existing).
+        comment: Why the change was made.
+
+    Returns the updated row with validation result.
+    """
+    from datetime import datetime, timezone
+
+    from metta_nl_corpus.services.defs.transformation.assets import (
+        validate_expressions_by_label,
+    )
+
+    existing = store.get_annotation(annotation_id)
+    if existing is None:
+        return {"error": f"Annotation '{annotation_id}' not found."}
+
+    premise = (
+        metta_premise.strip() if metta_premise else existing.get("metta_premise")
+    ) or ""
+    hypothesis = (
+        metta_hypothesis.strip()
+        if metta_hypothesis
+        else existing.get("metta_hypothesis")
+    ) or ""
+
+    if not premise and not hypothesis:
+        return {"error": "Both metta_premise and metta_hypothesis are empty."}
+
+    label_str = existing.get("label", "")
+    if label_str == "contradication":
+        label_str = "contradiction"
+    try:
+        label = RelationKind(label_str)
+    except ValueError:
+        return {"error": f"Unknown label '{label_str}' on annotation."}
+
+    is_valid = validate_expressions_by_label(
+        label=label,
+        metta_premise=premise,
+        metta_hypothesis=hypothesis,
+    )
+
+    now = datetime.now(timezone.utc).isoformat()
+    store.update_annotation(
+        annotation_id,
+        {
+            "metta_premise": premise,
+            "metta_hypothesis": hypothesis,
+            "is_valid": is_valid,
+            "modification_date": now,
+            "modification_comment": comment,
+        },
+    )
+
+    logger.info(
+        "Cleaned annotation",
+        annotation_id=annotation_id,
+        is_valid=is_valid,
+        comment=comment,
+    )
+
+    updated = store.get_annotation(annotation_id)
+    if updated and isinstance(updated.get("system_prompt"), str):
+        updated["system_prompt"] = updated["system_prompt"][:100] + "..."
+
+    return {
+        "success": True,
+        "is_valid": is_valid,
+        "annotation": updated,
+    }
+
+
+@mcp.tool()
 def export_annotations_parquet(
     table: str = "annotations",
 ) -> dict[str, Any]:

--- a/metta_nl_corpus/models/__init__.py
+++ b/metta_nl_corpus/models/__init__.py
@@ -36,6 +36,8 @@ class Annotation(TrainingBase):
     input_tokens: int | None = Field(default=None, nullable=True)
     output_tokens: int | None = Field(default=None, nullable=True)
     fix_reason: str | None = Field(default=None, nullable=True)
+    modification_date: str | None = Field(default=None, nullable=True)
+    modification_comment: str | None = Field(default=None, nullable=True)
     version: str = Field(default=DATA_VERSION)
 
     class Config:


### PR DESCRIPTION
- Add `modification_date` and `modification_comment` columns to Annotation model
- Auto-migrate existing SQLite DBs via `_migrate_columns`
- New `clean_annotation` MCP tool: patch metta_premise and/or metta_hypothesis individually, re-validate, and record when/why the change was made