### PR TITLE
Add PeTTa backend adapter for MeTTa execution

### DIFF
--- a/metta_nl_corpus/lib/runner.py
+++ b/metta_nl_corpus/lib/runner.py
@@ -1,0 +1,124 @@
+"""MeTTa execution backend adapter.
+
+Provides a unified interface for running MeTTa code via either the
+hyperon-experimental runtime or the PeTTa (Prolog-based) transpiler.
+"""
+
+from __future__ import annotations
+
+import os
+import subprocess
+import tempfile
+from collections.abc import Sequence
+from enum import StrEnum
+from typing import Protocol
+
+from structlog import get_logger
+
+logger = get_logger(__name__)
+
+
+class MeTTaBackend(StrEnum):
+    HYPERON = "hyperon"
+    PETTA = "petta"
+
+
+class MeTTaRunner(Protocol):
+    """Minimal interface for executing MeTTa code."""
+
+    def run(self, code: str) -> Sequence[Sequence[str]]: ...
+
+
+class HyperonRunner:
+    """Wraps hyperon.MeTTa, converting Atom results to strings."""
+
+    def __init__(self) -> None:
+        from hyperon import MeTTa
+
+        self._runner = MeTTa()
+
+    def run(self, code: str) -> Sequence[Sequence[str]]:
+        raw: Sequence[Sequence[object]] = self._runner.run(code)
+        return [[str(atom) for atom in group] for group in raw]
+
+
+class PeTTaRunner:
+    """Accumulates MeTTa code and executes via PeTTa's run.sh.
+
+    Each call to ``run`` appends code to an internal buffer and re-executes
+    the full buffer through PeTTa, mirroring the stateful behaviour of the
+    hyperon runner.  Only the results of the last ``!``-expression matter
+    for validation, so full re-execution is correct.
+    """
+
+    def __init__(self, petta_path: str) -> None:
+        self._petta_path: str = petta_path
+        self._buffer: list[str] = []
+
+    def run(self, code: str) -> Sequence[Sequence[str]]:
+        self._buffer.append(code)
+        full_code: str = "\n".join(self._buffer)
+
+        with tempfile.NamedTemporaryFile(
+            mode="w", suffix=".metta", delete=False
+        ) as tmp:
+            tmp.write(full_code)
+            tmp_path: str = tmp.name
+
+        try:
+            result = subprocess.run(
+                ["sh", "run.sh", tmp_path],
+                cwd=self._petta_path,
+                capture_output=True,
+                text=True,
+                timeout=30,
+            )
+        finally:
+            os.unlink(tmp_path)
+
+        if result.returncode != 0:
+            logger.warning(
+                "PeTTa execution failed",
+                returncode=result.returncode,
+                stderr=result.stderr.strip(),
+            )
+            return []
+
+        return _parse_petta_output(result.stdout)
+
+
+def _parse_petta_output(stdout: str) -> Sequence[Sequence[str]]:
+    """Parse PeTTa stdout into list-of-lists using hyperon's parse_all."""
+    from metta_nl_corpus.lib.helpers import parse_all
+
+    lines: list[str] = [ln.strip() for ln in stdout.strip().splitlines() if ln.strip()]
+    results: list[Sequence[str]] = []
+    for line in lines:
+        if line.startswith("[") and line.endswith("]"):
+            inner: str = line[1:-1].strip()
+            if not inner:
+                results.append([])
+                continue
+            atoms = parse_all(inner)
+            results.append([str(a) for a in atoms])
+        else:
+            atoms = parse_all(line)
+            results.append([str(a) for a in atoms])
+    return results
+
+
+def create_runner(backend: MeTTaBackend | None = None) -> MeTTaRunner:
+    """Factory for MeTTa runners, defaulting to METTA_BACKEND env var."""
+    if backend is None:
+        backend = MeTTaBackend(os.environ.get("METTA_BACKEND", MeTTaBackend.HYPERON))
+
+    if backend == MeTTaBackend.PETTA:
+        petta_path: str | None = os.environ.get("PETTA_PATH")
+        if not petta_path:
+            msg = "PETTA_PATH env var is required when METTA_BACKEND=petta"
+            raise ValueError(msg)
+        logger.info("Using PeTTa backend", petta_path=petta_path)
+        return PeTTaRunner(petta_path)
+
+    logger.debug("Using Hyperon backend")
+    return HyperonRunner()

--- a/metta_nl_corpus/mcp_server.py
+++ b/metta_nl_corpus/mcp_server.py
@@ -23,6 +23,7 @@ from metta_nl_corpus.constants import (
     VALIDATIONS_PATH,
 )
 from metta_nl_corpus.lib.helpers import parse_all
+from metta_nl_corpus.lib.runner import create_runner
 from metta_nl_corpus.lib.storage import AnnotationStore
 from metta_nl_corpus.models import RelationKind
 
@@ -206,9 +207,7 @@ def execute_metta(
     Returns dict with ``results`` (list of result strings) or ``error``.
     """
     try:
-        from hyperon import MeTTa
-
-        runner = MeTTa()
+        runner = create_runner()
         raw_results = runner.run(metta_code)
         # raw_results is a list of lists (one per !-expression)
         results = []

--- a/metta_nl_corpus/services/defs/transformation/assets.py
+++ b/metta_nl_corpus/services/defs/transformation/assets.py
@@ -13,7 +13,6 @@ from dagster import asset
 from dotenv import load_dotenv
 from httpx import HTTPStatusError
 from huggingface_hub.utils.tqdm import tqdm
-from hyperon import MeTTa
 from pydantic import BaseModel, model_validator
 from pydantic_ai import Agent, RunContext
 from pydantic_ai.models.openai import OpenAIChatModel
@@ -36,6 +35,7 @@ from metta_nl_corpus.lib.helpers import (
     to_metta_tuple,
 )
 from metta_nl_corpus.lib.interfaces import Fn
+from metta_nl_corpus.lib.runner import create_runner
 from metta_nl_corpus.lib.pipeline_config import PipelineRunConfig
 from metta_nl_corpus.lib.space_versioning import get_space_version
 from metta_nl_corpus.models import (
@@ -335,7 +335,7 @@ def validate_expressions_truthy_after_adding_expressions_to_space(
     logger.info("Validating expressions", expressions=expressions_to_add_to_space)
 
     try:
-        runner = MeTTa()
+        runner = create_runner()
 
         # Read the file content
         with open(grounding_space_path, "r") as f:


### PR DESCRIPTION
- Introduces `MeTTaRunner` protocol with `HyperonRunner` and `PeTTaRunner` implementations
- `create_runner()` factory reads `METTA_BACKEND` env var (default: `hyperon`)
- PeTTa runner accumulates code, executes via `run.sh` subprocess, parses output with hyperon's `parse_all`
- Replaces direct `MeTTa()` usage in `assets.py` and `mcp_server.py`
- `PETTA_PATH` env var required when `METTA_BACKEND=petta`