### PR TITLE
Add offset parameter to revalidate_annotations

### DIFF
--- a/.claude/commands/review.md
+++ b/.claude/commands/review.md
@@ -1,10 +1,12 @@
 Review and fix MeTTa annotations from the SQLite store.
 
-Run with an optional number argument: `/review 20` (default: 10).
+Run with optional arguments: `/review 20` (default: 10), `/review 50 offset 100`.
+
+Parse `$ARGUMENTS`: extract a number for `limit` (default 10) and if the word `offset` appears, take the number after it as `offset` (default 0).
 
 ## 1. Revalidate
 
-Call `mcp__metta-nl-corpus__revalidate_annotations` with `limit` set to `$ARGUMENTS` (default 10). This picks annotations from the DB and checks them against the current inference engine.
+Call `mcp__metta-nl-corpus__revalidate_annotations` with `limit` and `offset` parsed from `$ARGUMENTS`. This picks annotations from the DB and checks them against the current inference engine.
 
 ## 2. Triage results
 

--- a/metta_nl_corpus/mcp_server.py
+++ b/metta_nl_corpus/mcp_server.py
@@ -827,6 +827,7 @@ def revalidate_annotations(
     save: bool = False,
     timeout: int = 5,
     limit: int = 10,
+    offset: int = 0,
 ) -> dict[str, Any]:
     """Re-validate stored annotations against the current inference engine.
 
@@ -838,6 +839,7 @@ def revalidate_annotations(
         save: Whether to persist updated is_valid flags to the DB. Default False (dry run).
         timeout: Per-row validation timeout in seconds (default 5).
         limit: Max rows to process (0 = all, default 10).
+        offset: Number of rows to skip before processing (default 0).
 
     Returns a summary with per-row results and aggregate counts.
     """
@@ -857,9 +859,13 @@ def revalidate_annotations(
     if label:
         query += " WHERE label = ?"
         params.append(label)
+    query += " ORDER BY annotation_id"
     if limit > 0:
         query += " LIMIT ?"
         params.append(str(limit))
+    if offset > 0:
+        query += " OFFSET ?"
+        params.append(str(offset))
 
     rows = [
         store._row_to_dict(dict(r), source="annotations")


### PR DESCRIPTION
## Summary
- Add `offset` parameter to `revalidate_annotations` MCP tool for paginating through annotations
- Add `ORDER BY annotation_id` for deterministic pagination
- Update `/review` skill to accept offset syntax: `/review 50 offset 100`