### PR TITLE
Accept list filter_value in query_annotations

### DIFF
--- a/metta_nl_corpus/lib/storage.py
+++ b/metta_nl_corpus/lib/storage.py
@@ -160,7 +160,7 @@ class AnnotationStore:
         self,
         table: str = "annotations",
         filter_column: str | None = None,
-        filter_value: str | None = None,
+        filter_value: str | list[str] | None = None,
         limit: int = 20,
     ) -> dict[str, Any]:
         """SELECT with optional filter. Returns {total, returned, columns, rows}."""
@@ -174,24 +174,15 @@ class AnnotationStore:
             _PL_TO_SQL.get(filter_column, filter_column) if filter_column else None
         )
 
+        # Build WHERE clause depending on scalar vs list filter_value.
+        where, params = self._build_where(sql_filter_col, filter_value)
+
         # Total count
-        if sql_filter_col and filter_value:
-            cur = conn.execute(
-                f"SELECT COUNT(*) FROM {table} WHERE {sql_filter_col} = ?",
-                (filter_value,),
-            )
-        else:
-            cur = conn.execute(f"SELECT COUNT(*) FROM {table}")
+        cur = conn.execute(f"SELECT COUNT(*) FROM {table}{where}", params)
         total = cur.fetchone()[0]
 
         # Fetch rows
-        if sql_filter_col and filter_value:
-            cur = conn.execute(
-                f"SELECT * FROM {table} WHERE {sql_filter_col} = ? LIMIT ?",
-                (filter_value, limit),
-            )
-        else:
-            cur = conn.execute(f"SELECT * FROM {table} LIMIT ?", (limit,))
+        cur = conn.execute(f"SELECT * FROM {table}{where} LIMIT ?", (*params, limit))
 
         rows = [self._row_to_dict(dict(r), source=table) for r in cur.fetchall()]
         col_names = (
@@ -267,6 +258,24 @@ class AnnotationStore:
         return count
 
     # -- helpers ---------------------------------------------------------------
+
+    @staticmethod
+    def _build_where(
+        column: str | None, value: str | list[str] | None
+    ) -> tuple[str, tuple[str, ...]]:
+        """Return a (WHERE clause, params) tuple.
+
+        Accepts a single string or a list of strings. Strings are never
+        iterated character-by-character — only ``list`` triggers IN().
+        """
+        if not column or value is None:
+            return "", ()
+        if isinstance(value, list):
+            if not value:
+                return " WHERE 1=0", ()
+            placeholders = ", ".join("?" for _ in value)
+            return f" WHERE {column} IN ({placeholders})", tuple(value)
+        return f" WHERE {column} = ?", (value,)
 
     @staticmethod
     def _row_to_dict(

--- a/metta_nl_corpus/mcp_server.py
+++ b/metta_nl_corpus/mcp_server.py
@@ -548,7 +548,7 @@ async def run_pipeline(
 def query_annotations(
     file: str = "annotations",
     filter_column: str | None = None,
-    filter_value: str | None = None,
+    filter_value: str | list[str] | None = None,
     limit: int = 20,
 ) -> dict[str, Any]:
     """Query annotations or validations parquet files.
@@ -556,7 +556,7 @@ def query_annotations(
     Args:
         file: Which file to query — "annotations", "validations", or "cleaned".
         filter_column: Optional column name to filter on.
-        filter_value: Value to match in the filter column.
+        filter_value: Value or list of values to match in the filter column.
         limit: Maximum number of rows to return (default 20).
 
     Returns matching rows as a list of dicts, plus the total count.
@@ -579,7 +579,11 @@ def query_annotations(
                 return {
                     "error": f"Column '{filter_column}' not found. Available: {df.columns}"
                 }
-            df = df.filter(pl.col(filter_column).cast(pl.Utf8) == filter_value)
+            col = pl.col(filter_column).cast(pl.Utf8)
+            if isinstance(filter_value, list):
+                df = df.filter(col.is_in(filter_value))
+            else:
+                df = df.filter(col == filter_value)
         total = len(df)
         rows = df.head(limit).to_dicts()
         columns = df.columns

--- a/tests/test_storage_query.py
+++ b/tests/test_storage_query.py
@@ -1,0 +1,107 @@
+"""Tests for AnnotationStore.query with scalar and list filter_value."""
+
+from __future__ import annotations
+
+
+import pytest
+
+from metta_nl_corpus.lib.storage import AnnotationStore
+
+
+@pytest.fixture()
+def store(tmp_path):
+    """Create a fresh in-memory-like store with three annotations."""
+    s = AnnotationStore(db_path=tmp_path / "test.db")
+    for i, label in enumerate(["entailment", "contradiction", "neutral"]):
+        s.insert_annotation(
+            {
+                "annotation_id": f"id-{i}",
+                "idx": i,
+                "label": label,
+                "premise": f"premise {i}",
+                "hypothesis": f"hypothesis {i}",
+                "metta_premise": f"(premise-{i})",
+                "metta_hypothesis": f"(hypothesis-{i})",
+                "model": "test",
+                "generation_model": "test",
+                "system_prompt": "test prompt",
+                "is_valid": True,
+                "version": "0.0.1",
+            }
+        )
+    return s
+
+
+class TestScalarFilterValue:
+    def test_single_string_returns_one_row(self, store):
+        result = store.query(filter_column="label", filter_value="entailment")
+        assert result["total"] == 1
+        assert result["rows"][0]["label"] == "entailment"
+
+    def test_string_not_iterated_as_chars(self, store):
+        """A string like 'neutral' must NOT be split into ['n','e','u',...]."""
+        result = store.query(filter_column="label", filter_value="neutral")
+        assert result["total"] == 1
+        assert result["rows"][0]["label"] == "neutral"
+
+    def test_no_filter_returns_all(self, store):
+        result = store.query()
+        assert result["total"] == 3
+
+
+class TestListFilterValue:
+    def test_list_of_ids(self, store):
+        result = store.query(
+            filter_column="annotation_id", filter_value=["id-0", "id-2"]
+        )
+        assert result["total"] == 2
+        returned_ids = {r["annotation_id"] for r in result["rows"]}
+        assert returned_ids == {"id-0", "id-2"}
+
+    def test_list_with_single_element(self, store):
+        result = store.query(filter_column="label", filter_value=["contradiction"])
+        assert result["total"] == 1
+
+    def test_empty_list_returns_nothing(self, store):
+        result = store.query(filter_column="label", filter_value=[])
+        assert result["total"] == 0
+        assert result["rows"] == []
+
+    def test_list_with_nonexistent_values(self, store):
+        result = store.query(filter_column="label", filter_value=["foo", "bar"])
+        assert result["total"] == 0
+
+
+class TestBuildWhereUnit:
+    """Direct unit tests for _build_where to verify SQL generation."""
+
+    def test_none_value(self):
+        clause, params = AnnotationStore._build_where("col", None)
+        assert clause == ""
+        assert params == ()
+
+    def test_none_column(self):
+        clause, params = AnnotationStore._build_where(None, "val")
+        assert clause == ""
+        assert params == ()
+
+    def test_scalar(self):
+        clause, params = AnnotationStore._build_where("col", "val")
+        assert clause == " WHERE col = ?"
+        assert params == ("val",)
+
+    def test_list(self):
+        clause, params = AnnotationStore._build_where("col", ["a", "b", "c"])
+        assert clause == " WHERE col IN (?, ?, ?)"
+        assert params == ("a", "b", "c")
+
+    def test_empty_list(self):
+        clause, params = AnnotationStore._build_where("col", [])
+        assert clause == " WHERE 1=0"
+        assert params == ()
+
+    def test_string_is_not_list(self):
+        """Critically: a string must produce = ?, not IN (?, ?, ...)."""
+        clause, params = AnnotationStore._build_where("col", "abc")
+        assert "IN" not in clause
+        assert params == ("abc",)


### PR DESCRIPTION
## Summary
- `query_annotations` and `AnnotationStore.query` now accept `filter_value: str | list[str] | None`
- List values use `IN()` (SQLite) / `is_in()` (Polars) for batch lookups
- Strings are strictly type-checked (`isinstance(value, list)`) to prevent character iteration
- Added 13 tests covering scalar, list, empty list, and `_build_where` unit tests