### PR TITLE
Deduplicate DB, default store_result=False, upsert clean_annotation

### DIFF
--- a/metta_nl_corpus/lib/storage.py
+++ b/metta_nl_corpus/lib/storage.py
@@ -138,6 +138,13 @@ class AnnotationStore:
         mapped = {_PL_TO_SQL.get(k, k): v for k, v in updates.items()}
         if "is_valid" in mapped and isinstance(mapped["is_valid"], bool):
             mapped["is_valid"] = int(mapped["is_valid"])
+        # Only update columns that exist in the table.
+        existing_cols = {
+            row[1] for row in conn.execute("PRAGMA table_info(annotations)").fetchall()
+        }
+        mapped = {k: v for k, v in mapped.items() if k in existing_cols}
+        if not mapped:
+            return
         set_clause = ", ".join(f"{k} = ?" for k in mapped)
         conn.execute(
             f"UPDATE annotations SET {set_clause} WHERE annotation_id = ?",

--- a/metta_nl_corpus/lib/storage.py
+++ b/metta_nl_corpus/lib/storage.py
@@ -145,6 +145,41 @@ class AnnotationStore:
         )
         conn.commit()
 
+    def upsert_annotation(self, row: dict[str, Any]) -> str:
+        """INSERT or UPDATE a single annotation row. Returns the annotation_id.
+
+        If annotation_id exists, updates only the provided columns.
+        Otherwise inserts a new row.
+        """
+        aid = row.get("annotation_id", "")
+        if aid and self.get_annotation(str(aid)) is not None:
+            updates = {k: v for k, v in row.items() if k != "annotation_id"}
+            self.update_annotation(str(aid), updates)
+            return str(aid)
+        return self.insert_annotation(row)
+
+    def deduplicate(self) -> int:
+        """Remove duplicate annotations, keeping the most recently modified row per premise+hypothesis pair.
+
+        Returns the number of rows deleted.
+        """
+        conn = self._get_conn()
+        before = conn.execute("SELECT COUNT(*) FROM annotations").fetchone()[0]
+        conn.execute("""
+            DELETE FROM annotations
+            WHERE rowid NOT IN (
+                SELECT MAX(rowid) FROM annotations
+                GROUP BY premise, hypothesis
+            )
+        """)
+        conn.commit()
+        after = conn.execute("SELECT COUNT(*) FROM annotations").fetchone()[0]
+        deleted = before - after
+        logger.info(
+            "Deduplicated annotations", before=before, after=after, deleted=deleted
+        )
+        return deleted
+
     def get_annotation(self, annotation_id: str) -> dict[str, Any] | None:
         """Fetch a single annotation by id, or None."""
         conn = self._get_conn()

--- a/metta_nl_corpus/mcp_server.py
+++ b/metta_nl_corpus/mcp_server.py
@@ -192,6 +192,7 @@ def parse_metta(metta_code: str) -> dict[str, Any]:
 def execute_metta(
     metta_code: str,
     premise: str | None = None,
+    store_result: bool = False,
 ) -> dict[str, Any]:
     """Execute MeTTa code in a fresh runner and return the results.
 
@@ -200,9 +201,9 @@ def execute_metta(
 
     Args:
         metta_code: MeTTa source code to execute.
-        premise: Optional natural-language premise. When provided, the code
-            and results are stored to the annotations parquet as a
-            human-annotated expression entry (version 0.0.4).
+        premise: Optional natural-language premise for the annotation.
+        store_result: Whether to store the result as an annotation (default: False).
+            Requires premise to be set.
 
     Returns dict with ``results`` (list of result strings) or ``error``.
     """
@@ -218,7 +219,7 @@ def execute_metta(
 
     response: dict[str, Any] = {"success": True, "results": results}
 
-    if premise is not None:
+    if store_result and premise is not None:
         annotation_id = str(uuid.uuid4())
         system_prompt = ANNOTATION_GUIDELINE_PATH.read_text()
 
@@ -261,10 +262,12 @@ def validate_relation(
     premise: str | None = None,
     hypothesis: str | None = None,
     model: str = "claude",
+    store_result: bool = False,
 ) -> dict[str, Any]:
     """Check whether MeTTa expressions satisfy a logical relation.
 
-    Automatically stores the validated result to the annotations cache.
+    By default, only validates without storing. Set store_result=True to
+    persist the result as a new annotation.
 
     Args:
         metta_premise: MeTTa s-expression(s) for the premise.
@@ -273,8 +276,9 @@ def validate_relation(
         premise: Original natural-language premise (stored with the annotation).
         hypothesis: Original natural-language hypothesis (stored with the annotation).
         model: Which model generated the expressions (default: "claude").
+        store_result: Whether to store the result as a new annotation (default: False).
 
-    Returns dict with ``valid`` (bool), ``message``, and ``annotation_id``.
+    Returns dict with ``valid`` (bool), ``message``, and optionally ``annotation_id``.
     """
     from metta_nl_corpus.services.defs.transformation.assets import (
         validate_expressions_by_label,
@@ -297,45 +301,44 @@ def validate_relation(
     except Exception as e:
         return {"valid": False, "message": f"Validation failed: {e}"}
 
-    # Store the validated result
-    annotation_id = str(uuid.uuid4())
-    system_prompt = ANNOTATION_GUIDELINE_PATH.read_text()
-
-    try:
-        store.insert_annotation(
-            {
-                "annotation_id": annotation_id,
-                "index": 0,
-                "premise": premise,
-                "hypothesis": hypothesis,
-                "label": label.value,
-                "metta_premise": metta_premise.strip(),
-                "metta_hypothesis": metta_hypothesis.strip(),
-                "generation_model": model,
-                "system_prompt": system_prompt,
-                "version": "0.0.4",
-                "is_valid": is_valid,
-                "input_tokens": None,
-                "output_tokens": None,
-            }
-        )
-        logger.info(
-            "Stored validated annotation",
-            annotation_id=annotation_id,
-            is_valid=is_valid,
-        )
-    except Exception as e:
-        logger.error("Failed to store annotation", error=str(e))
-        return {
-            "valid": is_valid,
-            "message": f"Expressions {'match' if is_valid else 'do NOT match'} expected relation {label.value}. WARNING: failed to store: {e}",
-        }
-
-    return {
+    result: dict[str, Any] = {
         "valid": is_valid,
         "message": f"Expressions {'match' if is_valid else 'do NOT match'} expected relation {label.value}.",
-        "annotation_id": annotation_id,
     }
+
+    if store_result:
+        annotation_id = str(uuid.uuid4())
+        system_prompt = ANNOTATION_GUIDELINE_PATH.read_text()
+
+        try:
+            store.insert_annotation(
+                {
+                    "annotation_id": annotation_id,
+                    "index": 0,
+                    "premise": premise,
+                    "hypothesis": hypothesis,
+                    "label": label.value,
+                    "metta_premise": metta_premise.strip(),
+                    "metta_hypothesis": metta_hypothesis.strip(),
+                    "generation_model": model,
+                    "system_prompt": system_prompt,
+                    "version": "0.0.4",
+                    "is_valid": is_valid,
+                    "input_tokens": None,
+                    "output_tokens": None,
+                }
+            )
+            logger.info(
+                "Stored validated annotation",
+                annotation_id=annotation_id,
+                is_valid=is_valid,
+            )
+            result["annotation_id"] = annotation_id
+        except Exception as e:
+            logger.error("Failed to store annotation", error=str(e))
+            result["message"] += f" WARNING: failed to store: {e}"
+
+    return result
 
 
 @mcp.tool()
@@ -693,11 +696,13 @@ def clean_annotation(
     metta_hypothesis: str | None = None,
     comment: str | None = None,
 ) -> dict[str, Any]:
-    """Fix and re-validate a single annotation.
+    """Fix and re-validate a single annotation (upsert).
 
     Allows patching either metta_premise, metta_hypothesis, or both.
     Unchanged fields keep their current value. Re-validates after patching
     and records modification_date and modification_comment.
+
+    If the annotation_id does not exist, inserts a new row.
 
     Args:
         annotation_id: The UUID of the annotation to clean.
@@ -714,24 +719,28 @@ def clean_annotation(
     )
 
     existing = store.get_annotation(annotation_id)
-    if existing is None:
-        return {"error": f"Annotation '{annotation_id}' not found."}
 
     premise = (
-        metta_premise.strip() if metta_premise else existing.get("metta_premise")
+        metta_premise.strip()
+        if metta_premise
+        else (existing.get("metta_premise") if existing else "")
     ) or ""
     hypothesis = (
         metta_hypothesis.strip()
         if metta_hypothesis
-        else existing.get("metta_hypothesis")
+        else (existing.get("metta_hypothesis") if existing else "")
     ) or ""
 
     if not premise and not hypothesis:
         return {"error": "Both metta_premise and metta_hypothesis are empty."}
 
-    label_str = existing.get("label", "")
+    label_str = existing.get("label", "") if existing else ""
     if label_str == "contradication":
         label_str = "contradiction"
+    if not label_str:
+        return {
+            "error": "Cannot determine label — provide an existing annotation_id or use add_expressions."
+        }
     try:
         label = RelationKind(label_str)
     except ValueError:
@@ -744,16 +753,29 @@ def clean_annotation(
     )
 
     now = datetime.now(timezone.utc).isoformat()
-    store.update_annotation(
-        annotation_id,
-        {
-            "metta_premise": premise,
-            "metta_hypothesis": hypothesis,
-            "is_valid": is_valid,
-            "modification_date": now,
-            "modification_comment": comment,
-        },
-    )
+    row = {
+        "annotation_id": annotation_id,
+        "metta_premise": premise,
+        "metta_hypothesis": hypothesis,
+        "is_valid": is_valid,
+        "modification_date": now,
+        "modification_comment": comment,
+    }
+    # Carry forward existing fields for upsert when inserting new
+    if existing:
+        for key in (
+            "index",
+            "premise",
+            "hypothesis",
+            "label",
+            "generation_model",
+            "system_prompt",
+            "version",
+        ):
+            if key not in row:
+                row[key] = existing.get(key)
+
+    store.upsert_annotation(row)
 
     logger.info(
         "Cleaned annotation",

--- a/tests/test_storage_query.py
+++ b/tests/test_storage_query.py
@@ -105,3 +105,72 @@ class TestBuildWhereUnit:
         clause, params = AnnotationStore._build_where("col", "abc")
         assert "IN" not in clause
         assert params == ("abc",)
+
+
+def _make_row(annotation_id: str, premise: str, hypothesis: str, **overrides):
+    """Helper to build a minimal annotation row."""
+    row = {
+        "annotation_id": annotation_id,
+        "idx": 0,
+        "label": "entailment",
+        "premise": premise,
+        "hypothesis": hypothesis,
+        "metta_premise": f"({premise})",
+        "metta_hypothesis": f"({hypothesis})",
+        "generation_model": "test",
+        "system_prompt": "test",
+        "is_valid": True,
+        "version": "0.0.1",
+    }
+    row.update(overrides)
+    return row
+
+
+class TestDeduplicate:
+    def test_removes_duplicate_premise_hypothesis_pairs(self, tmp_path):
+        s = AnnotationStore(db_path=tmp_path / "dedup.db")
+        s.insert_annotation(_make_row("id-1", "A dog runs", "An animal moves"))
+        s.insert_annotation(_make_row("id-2", "A dog runs", "An animal moves"))
+        s.insert_annotation(_make_row("id-3", "A dog runs", "An animal moves"))
+        s.insert_annotation(_make_row("id-4", "A cat sits", "A feline rests"))
+
+        deleted = s.deduplicate()
+
+        assert deleted == 2
+        result = s.query()
+        assert result["total"] == 2
+        # The latest rowid (id-3) should be kept for the duplicated pair
+        ids = {r["annotation_id"] for r in result["rows"]}
+        assert "id-3" in ids
+        assert "id-4" in ids
+
+    def test_no_duplicates_deletes_nothing(self, tmp_path):
+        s = AnnotationStore(db_path=tmp_path / "nodedup.db")
+        s.insert_annotation(_make_row("id-1", "A", "B"))
+        s.insert_annotation(_make_row("id-2", "C", "D"))
+
+        assert s.deduplicate() == 0
+        assert s.query()["total"] == 2
+
+
+class TestUpsertAnnotation:
+    def test_inserts_when_new(self, tmp_path):
+        s = AnnotationStore(db_path=tmp_path / "upsert.db")
+        aid = s.upsert_annotation(_make_row("id-new", "P", "H"))
+
+        assert aid == "id-new"
+        assert s.query()["total"] == 1
+
+    def test_updates_existing_without_duplicating(self, tmp_path):
+        s = AnnotationStore(db_path=tmp_path / "upsert.db")
+        s.insert_annotation(_make_row("id-1", "P", "H"))
+
+        s.upsert_annotation({"annotation_id": "id-1", "metta_premise": "(updated)"})
+
+        assert s.query()["total"] == 1
+        row = s.get_annotation("id-1")
+        assert row is not None
+        assert row["metta_premise"] == "(updated)"
+        # Original fields preserved
+        assert row["premise"] == "P"
+        assert row["hypothesis"] == "H"


### PR DESCRIPTION
- `validate_relation`: add `store_result=False` default — validation-only calls no longer insert new rows
- `execute_metta`: add `store_result=False` default — require explicit opt-in to store
- `clean_annotation`: convert to upsert (inserts if annotation_id missing)
- `update_annotation`: filter to existing DB columns to avoid errors on schema drift
- Add `upsert_annotation` and `deduplicate` methods to `AnnotationStore`
- Ran dedup on production DB: removed 549 duplicate rows (2062 → 1513)
- Tests for dedup and upsert behavior