### PR TITLE
Use claude-opus-4-6 as default model name

### DIFF
--- a/metta_nl_corpus/mcp_server.py
+++ b/metta_nl_corpus/mcp_server.py
@@ -113,7 +113,7 @@ def update_annotation_guideline(content: str) -> dict[str, Any]:
 def add_expressions(
     sentence: str,
     metta_expressions: str,
-    model: str = "claude",
+    model: str = "claude-opus-4-6",
 ) -> dict[str, Any]:
     """Append validated MeTTa expressions to the annotations cache.
 
@@ -261,7 +261,7 @@ def validate_relation(
     relation: str,
     premise: str | None = None,
     hypothesis: str | None = None,
-    model: str = "claude",
+    model: str = "claude-opus-4-6",
     store_result: bool = False,
 ) -> dict[str, Any]:
     """Check whether MeTTa expressions satisfy a logical relation.


### PR DESCRIPTION
## Summary
- Default model parameter in `add_expressions` and `validate_relation` changed from `"claude"` to `"claude-opus-4-6"`
- Updated existing DB entries and pushed 1510 validated annotations to HuggingFace dataset