### PR TITLE
Add yield_unannotated_pairs tool and /annotate skill

### DIFF
--- a/.claude/commands/annotate.md
+++ b/.claude/commands/annotate.md
@@ -1,0 +1,69 @@
+Annotate unannotated SNLI pairs with MeTTa expressions.
+
+Run with optional arguments: `/annotate 50` (default: 50), `/annotate 100 offset 20000`.
+
+Parse `$ARGUMENTS`: extract a number for `limit` (default 50) and if the word `offset` appears, take the number after it as `offset` (default 10000).
+
+## 1. Fetch unannotated pairs
+
+Call `mcp__metta-nl-corpus__yield_unannotated_pairs` with `limit` and `offset` parsed from the arguments. This returns SNLI premise/hypothesis/label triples that are not yet in the annotation DB.
+
+Show the user a summary: how many pairs returned, label distribution.
+
+## 2. Split into agent batches
+
+Write the returned pairs to `/tmp/annotate_pairs.json`. Split into batches of 25, and launch one parallel agent per batch.
+
+## 3. Each agent's task
+
+For every pair in the batch, the agent must:
+
+### Generate MeTTa expressions
+
+Follow the annotation guideline strictly. Key rules:
+
+#### Entailment
+Build transitive chains so the hypothesis is DERIVABLE from the premise:
+- Use the same entity names in premise and hypothesis
+- Add semantic bridges: `(derived-property base-property)` in the premise so `(base-property entity)` + bridge → `(derived-property entity)`
+- Keep hypothesis to max 2 atoms in a conjunction `(, atom1 atom2)`
+
+#### Contradiction
+The hypothesis MUST negate a premise property:
+- Use compound 2-element predicates ONLY: `(predicate entity)`, never `(pred arg1 arg2)`
+- Hypothesis uses `((is-not property) entity)` with the SAME entity from the premise
+- For semantic contradictions (walking vs eating), negate the premise action
+
+#### Neutral
+Hypothesis introduces NEW information that is neither derivable nor contradictory:
+- Do NOT reuse premise predicates in hypothesis
+- Do NOT use `is-not` on any premise property
+
+### Validate before saving
+
+Call `mcp__metta-nl-corpus__validate_relation` with:
+- `metta_premise`: the generated premise expressions
+- `metta_hypothesis`: the generated hypothesis expressions
+- `relation`: the label from the SNLI pair
+- `premise`: the NL premise
+- `hypothesis`: the NL hypothesis
+- `model`: "claude-opus-4-6"
+- `store_result`: **false** (validate only)
+
+If `valid: false`, try fixing once (common issues: entity mismatch, missing bridge, wrong negation form). If still invalid, skip and note it.
+
+### Save valid annotations
+
+Call `mcp__metta-nl-corpus__validate_relation` again with `store_result: true` to persist the annotation.
+
+### Report
+
+At the end, the agent reports: how many annotated successfully, how many skipped.
+
+## 4. Final summary
+
+After all agents complete, show the user:
+- Total pairs processed
+- Successfully annotated (with label breakdown)
+- Skipped/failed (list the NL pairs that couldn't be annotated)
+- New total annotation count in the DB

--- a/metta_nl_corpus/mcp_server.py
+++ b/metta_nl_corpus/mcp_server.py
@@ -848,6 +848,83 @@ def import_annotations_parquet(
 
 
 @mcp.tool()
+def yield_unannotated_pairs(
+    limit: int = 50,
+    offset: int = 10_000,
+    label: str | None = None,
+) -> dict[str, Any]:
+    """Yield premise/hypothesis pairs from SNLI that are not yet in the annotation store.
+
+    Scans the SNLI training set starting at `offset`, skips pairs whose
+    (premise, hypothesis) already exist in SQLite, and returns up to `limit`
+    unannotated pairs ready for annotation.
+
+    Args:
+        limit: Maximum number of unannotated pairs to return (default 50).
+        offset: Starting row index in the SNLI dataset (default 10_000).
+        label: Optional label filter — "entailment", "contradiction", or "neutral".
+
+    Returns a list of dicts with premise, hypothesis, label, and snli_index.
+    """
+    from metta_nl_corpus.lib.helpers import str_index
+
+    snli_path = Path(
+        __import__("huggingface_hub").hf_hub_download(
+            repo_id="stanfordnlp/snli",
+            filename="plain_text/train-00000-of-00001.parquet",
+            repo_type="dataset",
+        )
+    )
+    df = pl.read_parquet(snli_path)
+
+    # Map integer labels to strings
+    label_fn = str_index(RelationKind, RelationKind.NO_LABEL)
+    df = df.with_row_index("snli_index").with_columns(
+        pl.col("label").map_elements(label_fn, return_dtype=pl.Utf8).alias("label_str")
+    )
+
+    # Slice from offset
+    df = df.filter(pl.col("snli_index") >= offset)
+
+    # Filter by label if requested
+    if label:
+        df = df.filter(pl.col("label_str") == label.lower().strip())
+
+    # Exclude no_label rows
+    df = df.filter(pl.col("label_str") != RelationKind.NO_LABEL.value)
+
+    # Get existing (premise, hypothesis) pairs from SQLite
+    conn = store._get_conn()
+    existing = {
+        (row[0], row[1])
+        for row in conn.execute(
+            "SELECT premise, hypothesis FROM annotations"
+        ).fetchall()
+    }
+
+    results: list[dict[str, Any]] = []
+    for row in df.iter_rows(named=True):
+        if len(results) >= limit:
+            break
+        key = (row["premise"], row["hypothesis"])
+        if key not in existing:
+            results.append(
+                {
+                    "snli_index": row["snli_index"],
+                    "premise": row["premise"],
+                    "hypothesis": row["hypothesis"],
+                    "label": row["label_str"],
+                }
+            )
+
+    return {
+        "total_available": len(results),
+        "offset": offset,
+        "pairs": results,
+    }
+
+
+@mcp.tool()
 def revalidate_annotations(
     label: str | None = None,
     save: bool = True,


### PR DESCRIPTION
## Summary
- New MCP tool `yield_unannotated_pairs`: queries SNLI for pairs not in the annotation DB, starting at configurable offset (default 10k)
- New `/annotate` skill: orchestrates bulk annotation via parallel agents — fetch pairs, generate MeTTa, validate, store