### PR TITLE
Persist annotations per batch + recover failed validations

### DIFF
--- a/metta_nl_corpus/services/defs/transformation/assets.py
+++ b/metta_nl_corpus/services/defs/transformation/assets.py
@@ -1,6 +1,6 @@
 import asyncio
 from collections.abc import Sequence
-from contextvars import ContextVar
+
 from dataclasses import dataclass
 from datetime import datetime
 from pathlib import Path
@@ -52,9 +52,8 @@ logger = getLogger(__name__)
 load_dotenv(".env.local")
 
 # Stores the last generation attempt so callers can retrieve it on validation failure.
-last_generation_attempt: ContextVar[dict[str, Any] | None] = ContextVar(
-    "last_generation_attempt", default=None
-)
+# Module-level dict (not ContextVar) so it's visible across async task boundaries.
+last_generation_attempt: dict[str, Any] = {}
 
 ENTAILMENTS_PATH = PROJECT_ROOT / "metta_nl_corpus/services/spaces/inference.metta"
 CONTRADICTIONS_PATH = (
@@ -166,7 +165,7 @@ class AgentExpressionOutput(BaseModel):
         )
 
         # Store last attempt so callers can retrieve it on failure
-        last_generation_attempt.set(
+        last_generation_attempt.update(
             {
                 "metta_premise": metta_premise,
                 "metta_hypothesis": metta_hypothesis,
@@ -561,6 +560,19 @@ def _create_annotation_and_validation(
     return GenerateAndValidateResult(annotation=annotation, validation=validation)
 
 
+def _recover_last_attempt() -> tuple[str, str, int | None, int | None]:
+    """Recover the last generation attempt after validation failure."""
+    attempt = last_generation_attempt
+    if attempt.get("metta_premise") and attempt.get("metta_hypothesis"):
+        logger.warning(
+            "Recovering last generation attempt (validation failed)",
+            metta_premise=attempt["metta_premise"],
+            metta_hypothesis=attempt["metta_hypothesis"],
+        )
+        return (attempt["metta_premise"], attempt["metta_hypothesis"], None, None)
+    return ("", "", None, None)
+
+
 async def _generate_expressions_async(
     agent: Agent[ExpressionDeps, AgentExpressionOutput],
     premise: str,
@@ -580,7 +592,7 @@ async def _generate_expressions_async(
         result = await agent.run(prompt, deps=deps, model=annotation_model)
     except Exception as e:
         logger.error("Pydantic AI generation failed", error=str(e))
-        return ("", "", None, None)
+        return _recover_last_attempt()
 
     if not result.output:
         logger.error("Failed to generate MeTTa expressions")
@@ -633,7 +645,7 @@ def _generate_expressions_sync(
         result = agent.run_sync(prompt, deps=deps, model=annotation_model)
     except Exception as e:
         logger.error("Pydantic AI generation failed", error=str(e))
-        return ("", "", None, None)
+        return _recover_last_attempt()
 
     if not result.output:
         logger.error("Failed to generate MeTTa expressions")

--- a/metta_nl_corpus/services/defs/transformation/assets.py
+++ b/metta_nl_corpus/services/defs/transformation/assets.py
@@ -529,10 +529,8 @@ def _create_annotation_and_validation(
         "system_prompt": system_prompt,
         "version": DATA_VERSION,
     }
-    if input_tokens is not None:
-        record["input_tokens"] = input_tokens
-    if output_tokens is not None:
-        record["output_tokens"] = output_tokens
+    record["input_tokens"] = input_tokens
+    record["output_tokens"] = output_tokens
     annotation = Annotation.validate(pandera_record(record))
 
     is_valid = validate_expressions_by_label(

--- a/metta_nl_corpus/services/defs/transformation/assets.py
+++ b/metta_nl_corpus/services/defs/transformation/assets.py
@@ -1,5 +1,5 @@
 import asyncio
-from collections.abc import Sequence
+from collections.abc import Callable, Sequence
 
 from dataclasses import dataclass
 from datetime import datetime
@@ -809,6 +809,8 @@ async def process_in_batches_async(
     subset_size: int,
     batch_size: int,
     description: str = "Processing",
+    on_batch_complete: Callable[[Sequence[GenerateAndValidateResult]], None]
+    | None = None,
 ) -> Sequence[GenerateAndValidateResult]:
     """
     Process rows in batches asynchronously with progress tracking.
@@ -820,6 +822,7 @@ async def process_in_batches_async(
         subset_size: Maximum number of rows to process
         batch_size: Number of rows to process concurrently in each batch
         description: Description for the progress bar
+        on_batch_complete: Optional callback invoked after each batch with its results.
 
     Returns:
         List of processed results
@@ -843,6 +846,9 @@ async def process_in_batches_async(
         # Execute all tasks in the batch concurrently
         batch_results = await asyncio.gather(*tasks)
         processed_rows.extend(batch_results)
+
+        if on_batch_complete is not None:
+            on_batch_complete(batch_results)
 
     return processed_rows
 
@@ -946,6 +952,18 @@ def data_annotations(
 
     rows = dataset_to_annotate.to_dicts()
 
+    # Persist each batch to SQLite immediately so no work is lost
+    annotation_store = AnnotationStore(ANNOTATIONS_DB_PATH)
+
+    def _persist_batch(batch_results: Sequence[GenerateAndValidateResult]) -> None:
+        for result in batch_results:
+            if result.annotation is not None:
+                for row in result.annotation.to_dicts():
+                    annotation_store.insert_annotation(row)
+            if result.validation is not None:
+                for row in result.validation.to_dicts():
+                    annotation_store.insert_validation(row)
+
     # Run async batch processing
     processed_results = asyncio.run(
         process_in_batches_async(
@@ -954,55 +972,16 @@ def data_annotations(
             subset_size=pipeline_config.subset_size,
             batch_size=pipeline_config.batch_size,
             description="Generating MeTTa annotations",
+            on_batch_complete=_persist_batch,
         )
     )
 
     # Log cost summary for OpenAI models
     _log_batch_cost_summary(processed_results, pipeline_config.annotation_model)
 
-    # Separate annotations and validations
-    annotations_list = [
-        result.annotation
-        for result in processed_results
-        if result.annotation is not None
-    ]
-    validations_list = [
-        result.validation
-        for result in processed_results
-        if result.validation is not None
-    ]
-
-    # Create DataFrames by concatenating
-    new_annotations = (
-        pl.concat(annotations_list, how="vertical")
-        if annotations_list
-        else pl.DataFrame()
-    )
-    new_validations = (
-        pl.concat(validations_list, how="vertical")
-        if validations_list
-        else pl.DataFrame()
-    )
-
-    # Combine with cached data
-    all_annotations = (
-        pl.concat([cached_annotations, new_annotations], how="align")
-        if len(cached_annotations)
-        else new_annotations
-    )
-
-    all_validations = (
-        pl.concat([cached_validations, new_validations], how="align")
-        if len(cached_validations)
-        else new_validations
-    )
-
-    # Write to SQLite (atomic inserts) and export parquet for compatibility
-    annotation_store = AnnotationStore(ANNOTATIONS_DB_PATH)
-    for row in new_annotations.to_dicts():
-        annotation_store.insert_annotation(row)
-    for row in new_validations.to_dicts():
-        annotation_store.insert_validation(row)
+    # Reload from SQLite (includes both cached + newly persisted)
+    all_annotations = annotation_store.to_polars("annotations")
+    all_validations = annotation_store.to_polars("validations")
 
     # Export to parquet for HuggingFace / backward compatibility
     annotation_store.export_parquet(ANNOTATIONS_PATH, table="annotations")


### PR DESCRIPTION
- Persist each batch to SQLite immediately via on_batch_complete callback (no more losing hours of work if final step fails)
- Always include input_tokens/output_tokens in records to avoid DataFrame schema mismatch on concat