### PR TITLE
Add subprompt skill with IO monad pipeline

### DIFF
--- a/.claude/commands/subprompt.md
+++ b/.claude/commands/subprompt.md
@@ -1,0 +1,36 @@
+Convert the following natural language into MeTTa expressions, then parse, validate, and store them via the IO monad pipeline:
+
+"$ARGUMENTS"
+
+Follow these steps:
+
+## 1. Generate MeTTa expressions
+
+Convert the sentence into MeTTa s-expressions following the annotation guideline. Remember:
+- Every expression MUST be parenthesized: `(predicate subject)` or `(predicate subject object)`
+- Use `a-thing` or `the-thing` naming for particulars
+- Use bare class names for universals/categories
+- Use `is-a` for type hierarchies
+- Use `is-not` for negation (never bare `not`)
+- Use compound predicates for 2-element form: `(onHorse a-person)` not `(on a-person horse)`
+- Extract ALL concepts: explicit, implicit, properties, relations, inheritance
+
+## 2. Validate syntax
+
+Call `mcp__metta-nl-corpus__parse_metta` with the generated expressions to confirm they parse. Fix any errors.
+
+## 3. Store via IO monad
+
+Call `mcp__metta-nl-corpus__subprompt` with:
+- `sentence`: the original sentence ("$ARGUMENTS")
+- `metta_expressions`: all validated MeTTa expressions (newline-separated)
+- `model`: "claude-opus-4-6"
+
+This runs the full IO chain (parse -> log -> store) and returns a trace of each step.
+
+## 4. Output
+
+Show the user:
+1. The MeTTa expressions in a code block
+2. The IO trace summary (steps, success/failure)
+3. The annotation_id confirming storage

--- a/metta_nl_corpus/lib/io.py
+++ b/metta_nl_corpus/lib/io.py
@@ -9,14 +9,11 @@ from __future__ import annotations
 
 from collections.abc import Callable, Sequence
 from dataclasses import dataclass, field
-from typing import Any, TypeVar
+from typing import Any
 
 from structlog import get_logger
 
 logger = get_logger(__name__)
-
-T = TypeVar("T")
-U = TypeVar("U")
 
 
 # ---------------------------------------------------------------------------
@@ -39,17 +36,17 @@ class From[T]:
     def __bool__(self) -> bool:
         return self.val is not None
 
-    def __lshift__(self, method: Callable[[T], U]) -> From[U]:
+    def __lshift__[U](self, method: Callable[[T], U]) -> From[U]:
         return self.bind(method)
 
     def __and__(self, method: Callable[[T], Any]) -> From[T]:
         return self.effect(method)
 
     @classmethod
-    def unit(cls, val: U) -> From[U]:
+    def unit[U](cls, val: U) -> From[U]:
         return cls(val)
 
-    def bind(self, func: Callable[[T], U]) -> From[U]:
+    def bind[U](self, func: Callable[[T], U]) -> From[U]:
         return self.unit(func(self.val))
 
     def effect(self, func: Callable[[T], Any]) -> From[T]:
@@ -57,7 +54,7 @@ class From[T]:
         return self
 
 
-class Just(From[T]):
+class Just[T](From[T]):
     pass
 
 
@@ -65,17 +62,17 @@ class Nothing(From[None]):
     pass
 
 
-class Result(From[T]):
+class Result[T](From[T]):
     """Result monad — catches exceptions and wraps them as Err."""
 
-    def bind(self, func: Callable[[T], U]) -> Ok[U] | Err:
+    def bind[U](self, func: Callable[[T], U]) -> Ok[U] | Err:
         try:
             return Ok(func(self.val))
         except Exception as e:
             return Err(e)
 
 
-class Ok(Result[T]):
+class Ok[T](Result[T]):
     pass
 
 
@@ -99,7 +96,7 @@ class IOStep:
 
 
 @dataclass
-class IO(From[T]):
+class IO[T](From[T]):
     """IO monad that records each effectful step for traceability.
 
     Usage:
@@ -121,10 +118,10 @@ class IO(From[T]):
         return f"<IO[{status}] steps={len(self.log)} val={self.val!r}>"
 
     @classmethod
-    def unit(cls, val: U, log: list[IOStep] | None = None) -> IO[U]:
+    def unit[U](cls, val: U, log: list[IOStep] | None = None) -> IO[U]:
         return cls(val=val, log=log or [])
 
-    def bind(self, func: Callable[[T], U]) -> IO[U]:
+    def bind[U](self, func: Callable[[T], U]) -> IO[U]:
         step_name = getattr(func, "__name__", str(func))
         try:
             output = func(self.val)

--- a/metta_nl_corpus/lib/io.py
+++ b/metta_nl_corpus/lib/io.py
@@ -1,0 +1,167 @@
+"""IO monad for MeTTa expression pipeline.
+
+Vendored from JungeWerther/from (MIT license) with MeTTa-specific extensions.
+Wraps side-effectful operations (parsing, validation, storage) in a monadic
+chain so that each step is composable, traceable, and short-circuit-safe.
+"""
+
+from __future__ import annotations
+
+from collections.abc import Callable, Sequence
+from dataclasses import dataclass, field
+from typing import Any, TypeVar
+
+from structlog import get_logger
+
+logger = get_logger(__name__)
+
+T = TypeVar("T")
+U = TypeVar("U")
+
+
+# ---------------------------------------------------------------------------
+# Core From monad (vendored from encapsulation.base, MIT)
+# ---------------------------------------------------------------------------
+
+
+class From[T]:
+    """Base monadic wrapper with bind (<<) and effect (&) operators."""
+
+    def __init__(self, val: T = None) -> None:
+        self.val = val
+
+    def __eq__(self, other: object) -> bool:
+        return isinstance(other, From) and self.val == other.val
+
+    def __repr__(self) -> str:
+        return f"<{self.__class__.__name__} val=({self.val})>"
+
+    def __bool__(self) -> bool:
+        return self.val is not None
+
+    def __lshift__(self, method: Callable[[T], U]) -> From[U]:
+        return self.bind(method)
+
+    def __and__(self, method: Callable[[T], Any]) -> From[T]:
+        return self.effect(method)
+
+    @classmethod
+    def unit(cls, val: U) -> From[U]:
+        return cls(val)
+
+    def bind(self, func: Callable[[T], U]) -> From[U]:
+        return self.unit(func(self.val))
+
+    def effect(self, func: Callable[[T], Any]) -> From[T]:
+        func(self.val)
+        return self
+
+
+class Just(From[T]):
+    pass
+
+
+class Nothing(From[None]):
+    pass
+
+
+class Result(From[T]):
+    """Result monad — catches exceptions and wraps them as Err."""
+
+    def bind(self, func: Callable[[T], U]) -> Ok[U] | Err:
+        try:
+            return Ok(func(self.val))
+        except Exception as e:
+            return Err(e)
+
+
+class Ok(Result[T]):
+    pass
+
+
+class Err(Result[Exception]):
+    pass
+
+
+# ---------------------------------------------------------------------------
+# IO monad — chains side-effectful MeTTa operations
+# ---------------------------------------------------------------------------
+
+
+@dataclass
+class IOStep:
+    """A single recorded step in the IO chain."""
+
+    name: str
+    input: Any
+    output: Any
+    success: bool
+
+
+@dataclass
+class IO(From[T]):
+    """IO monad that records each effectful step for traceability.
+
+    Usage:
+        result = (
+            IO("some natural language")
+            << parse_step
+            << validate_step
+            << store_step
+        )
+        result.val   # final value
+        result.log   # list of IOStep records
+    """
+
+    val: T = None
+    log: list[IOStep] = field(default_factory=list)
+
+    def __repr__(self) -> str:
+        status = "ok" if self else "empty"
+        return f"<IO[{status}] steps={len(self.log)} val={self.val!r}>"
+
+    @classmethod
+    def unit(cls, val: U, log: list[IOStep] | None = None) -> IO[U]:
+        return cls(val=val, log=log or [])
+
+    def bind(self, func: Callable[[T], U]) -> IO[U]:
+        step_name = getattr(func, "__name__", str(func))
+        try:
+            output = func(self.val)
+            step = IOStep(name=step_name, input=self.val, output=output, success=True)
+            logger.debug("io_step", step=step_name, success=True)
+            return IO.unit(output, [*self.log, step])
+        except Exception as e:
+            step = IOStep(name=step_name, input=self.val, output=str(e), success=False)
+            logger.warning("io_step_failed", step=step_name, error=str(e))
+            return IO.unit(None, [*self.log, step])
+
+    def effect(self, func: Callable[[T], Any]) -> IO[T]:
+        step_name = getattr(func, "__name__", str(func))
+        try:
+            func(self.val)
+            step = IOStep(name=step_name, input=self.val, output=None, success=True)
+            self.log.append(step)
+        except Exception as e:
+            step = IOStep(name=step_name, input=self.val, output=str(e), success=False)
+            self.log.append(step)
+        return self
+
+    @property
+    def failed_steps(self) -> Sequence[IOStep]:
+        return [s for s in self.log if not s.success]
+
+    @property
+    def succeeded(self) -> bool:
+        return all(s.success for s in self.log)
+
+    def summary(self) -> dict[str, Any]:
+        return {
+            "steps": len(self.log),
+            "succeeded": self.succeeded,
+            "value": self.val,
+            "trace": [
+                {"name": s.name, "success": s.success, "output": s.output}
+                for s in self.log
+            ],
+        }

--- a/metta_nl_corpus/mcp_server.py
+++ b/metta_nl_corpus/mcp_server.py
@@ -23,6 +23,7 @@ from metta_nl_corpus.constants import (
     VALIDATIONS_PATH,
 )
 from metta_nl_corpus.lib.helpers import parse_all
+from metta_nl_corpus.lib.io import IO
 from metta_nl_corpus.lib.runner import create_runner
 from metta_nl_corpus.lib.storage import AnnotationStore
 from metta_nl_corpus.models import RelationKind
@@ -1037,4 +1038,89 @@ def revalidate_annotations(
         "counts": counts,
         "results": results[:100],
         "truncated": len(results) > 100,
+    }
+
+
+# ---------------------------------------------------------------------------
+# Subprompt — IO-monadic parse-validate-store pipeline
+# ---------------------------------------------------------------------------
+
+
+def _parse_expressions(text: str) -> list[str]:
+    """Parse MeTTa code into atom strings."""
+    atoms = parse_all(text)
+    if not atoms:
+        raise ValueError("No valid MeTTa atoms found.")
+    return [str(a) for a in atoms]
+
+
+def _store_expressions(
+    sentence: str,
+    expressions: str,
+    model: str,
+) -> dict[str, Any]:
+    """Store parsed expressions in the annotation DB."""
+    annotation_id = str(uuid.uuid4())
+    system_prompt = ANNOTATION_GUIDELINE_PATH.read_text()
+    store.insert_annotation(
+        {
+            "annotation_id": annotation_id,
+            "index": 0,
+            "premise": sentence,
+            "hypothesis": None,
+            "label": RelationKind.EXPRESSION.value,
+            "metta_premise": expressions.strip(),
+            "metta_hypothesis": None,
+            "generation_model": model,
+            "system_prompt": system_prompt,
+            "version": "0.0.4",
+            "is_valid": True,
+            "input_tokens": None,
+            "output_tokens": None,
+        }
+    )
+    return {"annotation_id": annotation_id}
+
+
+@mcp.tool()
+def subprompt(
+    sentence: str,
+    metta_expressions: str,
+    model: str = "claude-opus-4-6",
+) -> dict[str, Any]:
+    """Parse, validate, and store MeTTa expressions via an IO monad chain.
+
+    Accepts a natural-language sentence and its MeTTa translation. Runs the
+    full pipeline (parse -> validate -> store) as a monadic IO chain, returning
+    a trace of each step.
+
+    Args:
+        sentence: The original natural-language sentence.
+        metta_expressions: Generated MeTTa expressions (newline-separated).
+        model: Which model generated the expressions.
+
+    Returns a summary with step trace and the stored annotation_id.
+    """
+    result = IO(metta_expressions) << _parse_expressions & (
+        lambda atoms: logger.info("parsed", atoms=atoms)
+    )
+
+    if not result.succeeded:
+        return {**result.summary(), "success": False}
+
+    # Store the original text (not the atom list) in the DB
+    store_result = IO(metta_expressions) << (
+        lambda expr: _store_expressions(sentence, expr, model)
+    )
+
+    # Merge traces
+    merged = IO.unit(
+        store_result.val,
+        [*result.log, *store_result.log],
+    )
+
+    return {
+        **merged.summary(),
+        "success": merged.succeeded,
+        "atoms": result.val,
     }


### PR DESCRIPTION
## Summary
- Vendors the `From` library (JungeWerther/from) as `metta_nl_corpus/lib/io.py` — IO monad that records each side-effectful step (parse, validate, store) in a traceable chain
- Adds `subprompt` MCP tool that runs parse -> log -> store as a monadic IO pipeline
- Adds `/subprompt` Claude Code skill that converts natural language to MeTTa expressions and stores them via the IO chain