### PR TITLE
Fix PeTTa load_file serialization mismatch

### DIFF
--- a/metta_nl_corpus/lib/runner.py
+++ b/metta_nl_corpus/lib/runner.py
@@ -11,7 +11,8 @@ import os
 import subprocess
 import sys
 import tempfile
-from collections.abc import Sequence
+from collections.abc import Iterator, Sequence
+from contextlib import contextmanager
 from enum import StrEnum
 from typing import Protocol
 
@@ -151,6 +152,7 @@ class JanusPeTTaRunner:
         from petta import PeTTa  # type: ignore[import-untyped]
 
         self._petta = PeTTa(petta_path=resolved)
+        self._baseline_funs = self._snapshot_funs()
 
     def run(self, code: str) -> Sequence[Sequence[str]]:
         serialized = _serialize_for_petta(code)
@@ -170,6 +172,60 @@ class JanusPeTTaRunner:
             lines = f.readlines()
         code = "".join(line for line in lines if not line.lstrip().startswith(";"))
         return self.run(code)
+
+    @staticmethod
+    def _snapshot_funs() -> set[tuple[str, int]]:
+        """Return the current set of (functor, arity) for user functions."""
+        import janus_swi as janus  # type: ignore[import-untyped]
+
+        try:
+            return {(r["F"], r["A"]) for r in janus.query("arity(F, A)")}
+        except Exception:
+            return set()
+
+    def reset(self) -> None:
+        """Retract all dynamic facts and user-defined functions.
+
+        Abolishes every ``&a/N`` predicate and retracts compiled function
+        clauses added after construction, restoring the engine to its
+        post-consult state so the next ``load_file`` starts clean.
+        """
+        import janus_swi as janus  # type: ignore[import-untyped]
+
+        # Clear space atoms
+        for row in list(janus.query("current_predicate('&a'/A)")):
+            janus.query_once(f"abolish('&a'/{row['A']})")
+
+        # Retract user functions added after baseline
+        added = self._snapshot_funs() - self._baseline_funs
+        for name, ar in added:
+            try:
+                janus.query_once(f"abolish('{name}'/{ar})")
+            except Exception:
+                pass
+        try:
+            janus.query_once("retractall(arity(_, _))")
+            for name, ar in self._baseline_funs:
+                janus.query_once(f"assertz(arity('{name}', {ar}))")
+        except Exception:
+            pass
+
+    @contextmanager
+    def fresh(self, path: str) -> Iterator[JanusPeTTaRunner]:
+        """Context manager: reset, load a space file, yield self, reset.
+
+        Usage::
+
+            with runner.fresh("path/to/inference-petta.metta") as r:
+                r.run('!(add-proposition (white swan))')
+                result = r.run('!(find-evidence-for (white swan))')
+        """
+        self.reset()
+        self.load_file(path)
+        try:
+            yield self
+        finally:
+            self.reset()
 
 
 def _parse_janus_output(raw: object) -> Sequence[Sequence[str]]:

--- a/metta_nl_corpus/lib/runner.py
+++ b/metta_nl_corpus/lib/runner.py
@@ -158,9 +158,18 @@ class JanusPeTTaRunner:
         return _parse_janus_output(raw)
 
     def load_file(self, path: str) -> Sequence[Sequence[str]]:
-        """Load a .metta file directly (avoids string-quoting issues)."""
-        raw = self._petta.load_metta_file(path)
-        return _parse_janus_output(raw)
+        """Load a .metta file, serializing operators for Prolog consistency.
+
+        Reads the file, strips comments (which may contain characters that
+        break Prolog string parsing), serializes MeTTa operators to
+        Prolog-safe names, and processes via ``process_metta_string``.
+        This ensures atoms stored during file loading use the same
+        representation as atoms added at runtime via ``run()``.
+        """
+        with open(path) as f:
+            lines = f.readlines()
+        code = "".join(line for line in lines if not line.lstrip().startswith(";"))
+        return self.run(code)
 
 
 def _parse_janus_output(raw: object) -> Sequence[Sequence[str]]:

--- a/tests/test_inference_petta.py
+++ b/tests/test_inference_petta.py
@@ -4,214 +4,147 @@ Mirrors key tests from test_inference_engine.py to verify that PeTTa
 produces identical results to the Hyperon runner.  Uses inference-petta.metta
 (the Prolog-safe variant) loaded via JanusPeTTaRunner.load_file, which is
 the same path the MCP server uses.
-
-Because JanusPeTTa shares a single in-process Prolog engine, each test
-uses a fresh subprocess to guarantee isolation.
 """
 
 from __future__ import annotations
 
-import subprocess
-import sys
-import textwrap
+from pathlib import Path
 
 import pytest
 
+from metta_nl_corpus.lib.runner import JanusPeTTaRunner
 
-def _run_petta_script(script: str) -> str:
-    """Run a PeTTa test script in an isolated subprocess."""
-    wrapper = textwrap.dedent(f"""\
-        import sys, os
-        sys.path.insert(0, os.path.join(os.environ.get("PETTA_PATH", os.path.expanduser("~/sites/PeTTa")), "python"))
-        from metta_nl_corpus.lib.runner import JanusPeTTaRunner
-        from pathlib import Path
+INFERENCE_PETTA_PATH = str(
+    Path(__file__).parent.parent
+    / "metta_nl_corpus"
+    / "services"
+    / "spaces"
+    / "inference-petta.metta"
+)
 
-        INFERENCE_PETTA_PATH = str(
-            Path("metta_nl_corpus/services/spaces/inference-petta.metta")
-        )
-
-        runner = JanusPeTTaRunner()
-        runner.load_file(INFERENCE_PETTA_PATH)
-
-        {textwrap.indent(script, "        ").strip()}
-    """)
-    result = subprocess.run(
-        [sys.executable, "-c", wrapper],
-        capture_output=True,
-        text=True,
-        timeout=30,
-        cwd=str(__import__("pathlib").Path(__file__).parent.parent),
-    )
-    if result.returncode != 0:
-        pytest.fail(f"Script failed:\n{result.stderr}")
-    return result.stdout.strip()
+_runner = JanusPeTTaRunner()
 
 
-def _truthy(output: str) -> bool:
-    return output == "True"
+@pytest.fixture()
+def runner():
+    with _runner.fresh(INFERENCE_PETTA_PATH) as r:
+        yield r
+
+
+def _truthy(result: list) -> bool:
+    return bool(result and len(result[-1]) > 0)
 
 
 # === Entailment ===
 
 
-def test_direct_entailment():
-    out = _run_petta_script("""\
-runner.run("!(add-proposition (A B))")
-r = runner.run("!(find-evidence-for (A B))")
-print(bool(r and len(r[-1]) > 0))
-""")
-    assert _truthy(out)
+def test_direct_entailment(runner):
+    runner.run("!(add-proposition (A B))")
+    assert _truthy(runner.run("!(find-evidence-for (A B))"))
 
 
-def test_transitivity_unary():
-    out = _run_petta_script("""\
-runner.run("!(add-proposition (white swan))")
-runner.run("!(add-proposition (swan this-swan))")
-r = runner.run("!(find-evidence-for (white this-swan))")
-print(bool(r and len(r[-1]) > 0))
-""")
-    assert _truthy(out)
+def test_transitivity_unary(runner):
+    runner.run("!(add-proposition (white swan))")
+    runner.run("!(add-proposition (swan this-swan))")
+    assert _truthy(runner.run("!(find-evidence-for (white this-swan))"))
 
 
-def test_transitivity_two_hop():
-    out = _run_petta_script("""\
-runner.run("!(add-proposition (animal mammal))")
-runner.run("!(add-proposition (mammal dog))")
-runner.run("!(add-proposition (dog fido))")
-r = runner.run("!(find-evidence-for (animal fido))")
-print(bool(r and len(r[-1]) > 0))
-""")
-    assert _truthy(out)
+def test_transitivity_two_hop(runner):
+    runner.run("!(add-proposition (animal mammal))")
+    runner.run("!(add-proposition (mammal dog))")
+    runner.run("!(add-proposition (dog fido))")
+    assert _truthy(runner.run("!(find-evidence-for (animal fido))"))
 
 
-def test_binary_entailment():
-    out = _run_petta_script("""\
-runner.run("!(add-proposition (held-by this-swan this-human))")
-runner.run("!(add-proposition (human this-human))")
-r = runner.run("!(find-evidence-for (held-by this-swan human))")
-print(bool(r and len(r[-1]) > 0))
-""")
-    assert _truthy(out)
+def test_binary_entailment(runner):
+    runner.run("!(add-proposition (held-by this-swan this-human))")
+    runner.run("!(add-proposition (human this-human))")
+    assert _truthy(runner.run("!(find-evidence-for (held-by this-swan human))"))
 
 
 # === Contradiction ===
 
 
-def test_basic_contradiction():
-    out = _run_petta_script("""\
-runner.run("!(add-proposition (A B))")
-runner.run("!(add-proposition (is-not A B))")
-r = runner.run("!(find-evidence-for ⊥)")
-print(bool(r and len(r[-1]) > 0))
-""")
-    assert _truthy(out), "should detect (A B) vs (is-not A B) as contradiction"
+def test_basic_contradiction(runner):
+    runner.run("!(add-proposition (A B))")
+    runner.run("!(add-proposition (is-not A B))")
+    r = runner.run("!(find-evidence-for ⊥)")
+    assert _truthy(r), "should detect (A B) vs (is-not A B) as contradiction"
 
 
-def test_contradiction_wrapped_form():
-    out = _run_petta_script("""\
-runner.run("!(add-proposition (A B))")
-runner.run("!(add-proposition (is-not (A B)))")
-r = runner.run("!(find-evidence-for ⊥)")
-print(bool(r and len(r[-1]) > 0))
-""")
-    assert _truthy(out)
+def test_contradiction_wrapped_form(runner):
+    runner.run("!(add-proposition (A B))")
+    runner.run("!(add-proposition (is-not (A B)))")
+    assert _truthy(runner.run("!(find-evidence-for ⊥)"))
 
 
-def test_contradiction_curried_form():
-    out = _run_petta_script("""\
-runner.run("!(add-proposition (A B))")
-runner.run("!(add-proposition ((is-not A) B))")
-r = runner.run("!(find-evidence-for ⊥)")
-print(bool(r and len(r[-1]) > 0))
-""")
-    assert _truthy(out)
+def test_contradiction_curried_form(runner):
+    runner.run("!(add-proposition (A B))")
+    runner.run("!(add-proposition ((is-not A) B))")
+    assert _truthy(runner.run("!(find-evidence-for ⊥)"))
 
 
-def test_binary_predicate_contradiction():
-    out = _run_petta_script("""\
-runner.run("!(add-proposition (held-by swan human))")
-runner.run("!(add-proposition (is-not held-by swan human))")
-r = runner.run("!(find-evidence-for ⊥)")
-print(bool(r and len(r[-1]) > 0))
-""")
-    assert _truthy(out)
+def test_binary_predicate_contradiction(runner):
+    runner.run("!(add-proposition (held-by swan human))")
+    runner.run("!(add-proposition (is-not held-by swan human))")
+    assert _truthy(runner.run("!(find-evidence-for ⊥)"))
 
 
-def test_contradiction_via_transitivity():
-    out = _run_petta_script("""\
-runner.run("!(add-proposition (held-by this-swan this-human))")
-runner.run("!(add-proposition (human this-human))")
-runner.run("!(add-proposition (is-not held-by this-swan human))")
-r = runner.run("!(find-evidence-for ⊥)")
-print(bool(r and len(r[-1]) > 0))
-""")
-    assert _truthy(out)
+def test_contradiction_via_transitivity(runner):
+    runner.run("!(add-proposition (held-by this-swan this-human))")
+    runner.run("!(add-proposition (human this-human))")
+    runner.run("!(add-proposition (is-not held-by this-swan human))")
+    assert _truthy(runner.run("!(find-evidence-for ⊥)"))
 
 
-def test_no_contradiction():
-    out = _run_petta_script("""\
-runner.run("!(add-proposition (A B))")
-runner.run("!(add-proposition (C D))")
-r = runner.run("!(find-evidence-for ⊥)")
-print(bool(r and len(r[-1]) > 0))
-""")
-    assert not _truthy(out), "unrelated facts should not contradict"
+def test_no_contradiction(runner):
+    runner.run("!(add-proposition (A B))")
+    runner.run("!(add-proposition (C D))")
+    assert not _truthy(runner.run("!(find-evidence-for ⊥)"))
 
 
 # === Numeric contradiction ===
 
 
 @pytest.mark.xfail(
-    reason="PeTTa cannot evaluate numeric guards (if (< $b $a) ...) under Prolog instantiation"
+    reason="PeTTa cannot evaluate numeric guards under Prolog instantiation"
 )
-def test_numeric_contradiction_gt_lt():
-    out = _run_petta_script("""\
-runner.run("!(add-atom &a (> price 60))")
-runner.run("!(add-atom &a (< price 50))")
-r = runner.run("!(find-evidence-for ⊥)")
-print(bool(r and len(r[-1]) > 0))
-""")
-    assert _truthy(out)
+def test_numeric_contradiction_gt_lt(runner):
+    runner.run("!(add-atom &a (> price 60))")
+    runner.run("!(add-atom &a (< price 50))")
+    assert _truthy(runner.run("!(find-evidence-for ⊥)"))
 
 
-def test_numeric_no_contradiction_overlapping():
-    out = _run_petta_script("""\
-runner.run("!(add-atom &a (> price 60))")
-runner.run("!(add-atom &a (< price 70))")
-r = runner.run("!(find-evidence-for ⊥)")
-print(bool(r and len(r[-1]) > 0))
-""")
-    assert not _truthy(out)
+def test_numeric_no_contradiction_overlapping(runner):
+    runner.run("!(add-atom &a (> price 60))")
+    runner.run("!(add-atom &a (< price 70))")
+    assert not _truthy(runner.run("!(find-evidence-for ⊥)"))
 
 
 # === Open variable queries ===
 
 
-def test_open_variable_query():
-    out = _run_petta_script("""\
-runner.run("!(add-proposition (white swan))")
-runner.run("!(add-proposition (swan fido))")
-r = runner.run("!(find-evidence-for ($what fido))")
-results = " ".join(str(x) for x in r[-1]) if r and r[-1] else ""
-print("swan" in results and "white" in results)
-""")
-    assert _truthy(out)
+def test_open_variable_query(runner):
+    runner.run("!(add-proposition (white swan))")
+    runner.run("!(add-proposition (swan fido))")
+    r = runner.run("!(find-evidence-for ($what fido))")
+    assert _truthy(r)
+    all_results = " ".join(str(x) for x in r[-1])
+    assert "swan" in all_results
+    assert "white" in all_results
 
 
 # === Match consistency (regression for serialization mismatch) ===
 
 
-def test_load_file_match_consistency():
+def test_load_file_match_consistency(runner):
     """Atoms stored via load_file must be matchable with structured patterns.
 
     Regression test for the bug where load_file stored '=>' but runtime
     queries used '__metta_implies__', making preloaded axioms invisible.
     """
-    out = _run_petta_script("""\
-r = runner.run("!(match &a (=> $x ⊥) $x)")
-print(bool(r and len(r[-1]) > 0))
-""")
-    assert _truthy(out), (
+    r = runner.run("!(match &a (=> $x ⊥) $x)")
+    assert _truthy(r), (
         "contradiction axioms loaded via load_file should be matchable "
         "with structured (=> $x ⊥) pattern"
     )

--- a/tests/test_inference_petta.py
+++ b/tests/test_inference_petta.py
@@ -1,0 +1,217 @@
+"""End-to-end inference tests using the JanusPeTTa (Prolog) backend.
+
+Mirrors key tests from test_inference_engine.py to verify that PeTTa
+produces identical results to the Hyperon runner.  Uses inference-petta.metta
+(the Prolog-safe variant) loaded via JanusPeTTaRunner.load_file, which is
+the same path the MCP server uses.
+
+Because JanusPeTTa shares a single in-process Prolog engine, each test
+uses a fresh subprocess to guarantee isolation.
+"""
+
+from __future__ import annotations
+
+import subprocess
+import sys
+import textwrap
+
+import pytest
+
+
+def _run_petta_script(script: str) -> str:
+    """Run a PeTTa test script in an isolated subprocess."""
+    wrapper = textwrap.dedent(f"""\
+        import sys, os
+        sys.path.insert(0, os.path.join(os.environ.get("PETTA_PATH", os.path.expanduser("~/sites/PeTTa")), "python"))
+        from metta_nl_corpus.lib.runner import JanusPeTTaRunner
+        from pathlib import Path
+
+        INFERENCE_PETTA_PATH = str(
+            Path("metta_nl_corpus/services/spaces/inference-petta.metta")
+        )
+
+        runner = JanusPeTTaRunner()
+        runner.load_file(INFERENCE_PETTA_PATH)
+
+        {textwrap.indent(script, "        ").strip()}
+    """)
+    result = subprocess.run(
+        [sys.executable, "-c", wrapper],
+        capture_output=True,
+        text=True,
+        timeout=30,
+        cwd=str(__import__("pathlib").Path(__file__).parent.parent),
+    )
+    if result.returncode != 0:
+        pytest.fail(f"Script failed:\n{result.stderr}")
+    return result.stdout.strip()
+
+
+def _truthy(output: str) -> bool:
+    return output == "True"
+
+
+# === Entailment ===
+
+
+def test_direct_entailment():
+    out = _run_petta_script("""\
+runner.run("!(add-proposition (A B))")
+r = runner.run("!(find-evidence-for (A B))")
+print(bool(r and len(r[-1]) > 0))
+""")
+    assert _truthy(out)
+
+
+def test_transitivity_unary():
+    out = _run_petta_script("""\
+runner.run("!(add-proposition (white swan))")
+runner.run("!(add-proposition (swan this-swan))")
+r = runner.run("!(find-evidence-for (white this-swan))")
+print(bool(r and len(r[-1]) > 0))
+""")
+    assert _truthy(out)
+
+
+def test_transitivity_two_hop():
+    out = _run_petta_script("""\
+runner.run("!(add-proposition (animal mammal))")
+runner.run("!(add-proposition (mammal dog))")
+runner.run("!(add-proposition (dog fido))")
+r = runner.run("!(find-evidence-for (animal fido))")
+print(bool(r and len(r[-1]) > 0))
+""")
+    assert _truthy(out)
+
+
+def test_binary_entailment():
+    out = _run_petta_script("""\
+runner.run("!(add-proposition (held-by this-swan this-human))")
+runner.run("!(add-proposition (human this-human))")
+r = runner.run("!(find-evidence-for (held-by this-swan human))")
+print(bool(r and len(r[-1]) > 0))
+""")
+    assert _truthy(out)
+
+
+# === Contradiction ===
+
+
+def test_basic_contradiction():
+    out = _run_petta_script("""\
+runner.run("!(add-proposition (A B))")
+runner.run("!(add-proposition (is-not A B))")
+r = runner.run("!(find-evidence-for ⊥)")
+print(bool(r and len(r[-1]) > 0))
+""")
+    assert _truthy(out), "should detect (A B) vs (is-not A B) as contradiction"
+
+
+def test_contradiction_wrapped_form():
+    out = _run_petta_script("""\
+runner.run("!(add-proposition (A B))")
+runner.run("!(add-proposition (is-not (A B)))")
+r = runner.run("!(find-evidence-for ⊥)")
+print(bool(r and len(r[-1]) > 0))
+""")
+    assert _truthy(out)
+
+
+def test_contradiction_curried_form():
+    out = _run_petta_script("""\
+runner.run("!(add-proposition (A B))")
+runner.run("!(add-proposition ((is-not A) B))")
+r = runner.run("!(find-evidence-for ⊥)")
+print(bool(r and len(r[-1]) > 0))
+""")
+    assert _truthy(out)
+
+
+def test_binary_predicate_contradiction():
+    out = _run_petta_script("""\
+runner.run("!(add-proposition (held-by swan human))")
+runner.run("!(add-proposition (is-not held-by swan human))")
+r = runner.run("!(find-evidence-for ⊥)")
+print(bool(r and len(r[-1]) > 0))
+""")
+    assert _truthy(out)
+
+
+def test_contradiction_via_transitivity():
+    out = _run_petta_script("""\
+runner.run("!(add-proposition (held-by this-swan this-human))")
+runner.run("!(add-proposition (human this-human))")
+runner.run("!(add-proposition (is-not held-by this-swan human))")
+r = runner.run("!(find-evidence-for ⊥)")
+print(bool(r and len(r[-1]) > 0))
+""")
+    assert _truthy(out)
+
+
+def test_no_contradiction():
+    out = _run_petta_script("""\
+runner.run("!(add-proposition (A B))")
+runner.run("!(add-proposition (C D))")
+r = runner.run("!(find-evidence-for ⊥)")
+print(bool(r and len(r[-1]) > 0))
+""")
+    assert not _truthy(out), "unrelated facts should not contradict"
+
+
+# === Numeric contradiction ===
+
+
+@pytest.mark.xfail(
+    reason="PeTTa cannot evaluate numeric guards (if (< $b $a) ...) under Prolog instantiation"
+)
+def test_numeric_contradiction_gt_lt():
+    out = _run_petta_script("""\
+runner.run("!(add-atom &a (> price 60))")
+runner.run("!(add-atom &a (< price 50))")
+r = runner.run("!(find-evidence-for ⊥)")
+print(bool(r and len(r[-1]) > 0))
+""")
+    assert _truthy(out)
+
+
+def test_numeric_no_contradiction_overlapping():
+    out = _run_petta_script("""\
+runner.run("!(add-atom &a (> price 60))")
+runner.run("!(add-atom &a (< price 70))")
+r = runner.run("!(find-evidence-for ⊥)")
+print(bool(r and len(r[-1]) > 0))
+""")
+    assert not _truthy(out)
+
+
+# === Open variable queries ===
+
+
+def test_open_variable_query():
+    out = _run_petta_script("""\
+runner.run("!(add-proposition (white swan))")
+runner.run("!(add-proposition (swan fido))")
+r = runner.run("!(find-evidence-for ($what fido))")
+results = " ".join(str(x) for x in r[-1]) if r and r[-1] else ""
+print("swan" in results and "white" in results)
+""")
+    assert _truthy(out)
+
+
+# === Match consistency (regression for serialization mismatch) ===
+
+
+def test_load_file_match_consistency():
+    """Atoms stored via load_file must be matchable with structured patterns.
+
+    Regression test for the bug where load_file stored '=>' but runtime
+    queries used '__metta_implies__', making preloaded axioms invisible.
+    """
+    out = _run_petta_script("""\
+r = runner.run("!(match &a (=> $x ⊥) $x)")
+print(bool(r and len(r[-1]) > 0))
+""")
+    assert _truthy(out), (
+        "contradiction axioms loaded via load_file should be matchable "
+        "with structured (=> $x ⊥) pattern"
+    )

--- a/tests/test_inference_petta.py
+++ b/tests/test_inference_petta.py
@@ -12,7 +12,16 @@ from pathlib import Path
 
 import pytest
 
-from metta_nl_corpus.lib.runner import JanusPeTTaRunner
+try:
+    from metta_nl_corpus.lib.runner import JanusPeTTaRunner
+
+    _runner = JanusPeTTaRunner()
+    _HAS_PETTA = True
+except (ImportError, ValueError):
+    _HAS_PETTA = False
+    _runner = None  # type: ignore[assignment]
+
+pytestmark = pytest.mark.skipif(not _HAS_PETTA, reason="PeTTa/janus-swi not available")
 
 INFERENCE_PETTA_PATH = str(
     Path(__file__).parent.parent
@@ -21,8 +30,6 @@ INFERENCE_PETTA_PATH = str(
     / "spaces"
     / "inference-petta.metta"
 )
-
-_runner = JanusPeTTaRunner()
 
 
 @pytest.fixture()


### PR DESCRIPTION
## Summary
- `JanusPeTTaRunner.load_file` stored MeTTa operators (`=>`, `⊥`) as raw symbols while `run()` serialized them to Prolog-safe names (`__metta_implies__`, `__metta_bottom__`). This made preloaded contradiction axioms invisible to runtime queries — `find-evidence-for ⊥` silently returned empty.
- Fix: `load_file` now reads the file, strips comments, and delegates to `run()` for consistent serialization.
- Adds 14 end-to-end PeTTa inference tests (entailment, contradiction, transitivity, open variables, and the regression case). Numeric contradiction marked xfail (known PeTTa limitation with Prolog instantiation guards).