### PR TITLE
Fix add-proposition-tv in PeTTa: let () -> let $_

### DIFF
--- a/metta_nl_corpus/services/spaces/inference-petta.metta
+++ b/metta_nl_corpus/services/spaces/inference-petta.metta
@@ -72,9 +72,11 @@
 (= (add-proposition ((is-not $rel) $ob $sub)) (add-atom &a (=> (, ($rel $ob $sub) ((is-not $rel) $ob $sub)) ⊥)))
 
 ;; === PLN Truth Values ===
+;; PeTTa-safe: add-atom returns `true` (not `()` as in Hyperon),
+;; so use $_ to discard the return value.
 (= (add-proposition-tv $prop (STV $s $c))
-   (let () (add-proposition $prop)
-     (let () (add-atom &a (≞ $prop (STV $s $c)))
+   (let $_ (add-proposition $prop)
+     (let $_ (add-atom &a (≞ $prop (STV $s $c)))
        (≞ $prop (STV $s $c)))))
 
 (= (get-tv $expr) (match &a (≞ $expr (STV $s $c)) (STV $s $c)))

--- a/tests/test_inference_petta.py
+++ b/tests/test_inference_petta.py
@@ -142,26 +142,17 @@ def test_open_variable_query(runner):
 
 
 # === PLN v2 format (STV-annotated facts) ===
-#
-# PeTTa cannot evaluate add-proposition-tv's let-chained side effects,
-# so we split into add-proposition + add-atom for the TV attachment.
-
-
-def _add_tv(runner, prop: str, s: str = "1.0", c: str = "0.9") -> None:
-    """Add a proposition with a truth value, PeTTa-safe."""
-    runner.run(f"!(add-proposition ({prop}))")
-    runner.run(f"!(add-atom &a (≞ ({prop}) (STV {s} {c})))")
 
 
 def test_v2_add_proposition_tv(runner):
-    """v2 format facts added with TV are retrievable."""
-    _add_tv(runner, "boy Boy1")
+    """v2 format facts added via add-proposition-tv are retrievable."""
+    runner.run("!(add-proposition-tv (boy Boy1) (STV 1.0 0.9))")
     assert _truthy(runner.run("!(find-evidence-for (boy Boy1))"))
 
 
 def test_v2_tv_retrieval(runner):
     """Truth value is retrievable after adding proposition with TV."""
-    _add_tv(runner, "boy Boy1")
+    runner.run("!(add-proposition-tv (boy Boy1) (STV 1.0 0.9))")
     r = runner.run("!(find-evidence-for-tv (boy Boy1))")
     assert _truthy(r)
     joined = " ".join(str(x) for x in r[-1])
@@ -170,8 +161,8 @@ def test_v2_tv_retrieval(runner):
 
 def test_v2_tv_propagation(runner):
     """Truth values propagate through transitive inference."""
-    _add_tv(runner, "animal mammal")
-    _add_tv(runner, "mammal Dog1")
+    runner.run("!(add-proposition-tv (animal mammal) (STV 1.0 0.9))")
+    runner.run("!(add-proposition-tv (mammal Dog1) (STV 1.0 0.9))")
     r = runner.run("!(find-evidence-for-tv (animal Dog1))")
     assert _truthy(r)
     joined = " ".join(str(x) for x in r[-1])
@@ -180,18 +171,18 @@ def test_v2_tv_propagation(runner):
 
 def test_v2_entailment_shared_witness(runner):
     """Entailment works when premise and hypothesis share a witness (v2 style)."""
-    _add_tv(runner, "boy Boy1")
-    _add_tv(runner, "little Boy1")
-    _add_tv(runner, "playing-with Boy1 Toy1")
-    _add_tv(runner, "toy Toy1")
+    runner.run("!(add-proposition-tv (boy Boy1) (STV 1.0 0.9))")
+    runner.run("!(add-proposition-tv (little Boy1) (STV 1.0 0.9))")
+    runner.run("!(add-proposition-tv (playing-with Boy1 Toy1) (STV 1.0 0.9))")
+    runner.run("!(add-proposition-tv (toy Toy1) (STV 1.0 0.9))")
     assert _truthy(runner.run("!(find-evidence-for (boy Boy1))"))
     assert _truthy(runner.run("!(find-evidence-for (playing-with Boy1 Toy1))"))
 
 
 def test_v2_neutral_no_derivation(runner):
     """Hypothesis-only predicates cannot be derived from premise (neutral)."""
-    _add_tv(runner, "boy Boy1")
-    _add_tv(runner, "playing-with Boy1 Toy1")
+    runner.run("!(add-proposition-tv (boy Boy1) (STV 1.0 0.9))")
+    runner.run("!(add-proposition-tv (playing-with Boy1 Toy1) (STV 1.0 0.9))")
     assert not _truthy(
         runner.run("!(find-evidence-for (caught-playing-with Boy1 Toy1))")
     )
@@ -200,17 +191,16 @@ def test_v2_neutral_no_derivation(runner):
 
 def test_v2_contradiction_with_tv(runner):
     """Contradiction detection works with STV-annotated facts."""
-    _add_tv(runner, "running Dog1")
-    runner.run("!(add-proposition ((is-not running) Dog1))")
-    runner.run("!(add-atom &a (≞ ((is-not running) Dog1) (STV 1.0 0.9)))")
+    runner.run("!(add-proposition-tv (running Dog1) (STV 1.0 0.9))")
+    runner.run("!(add-proposition-tv ((is-not running) Dog1) (STV 1.0 0.9))")
     assert _truthy(runner.run("!(find-evidence-for ⊥)"))
 
 
 def test_v2_transitive_entailment_with_tv(runner):
     """Transitive entailment with truth values across two hops."""
-    _add_tv(runner, "animal mammal", "0.95", "0.8")
-    _add_tv(runner, "mammal dog")
-    _add_tv(runner, "dog Fido1")
+    runner.run("!(add-proposition-tv (animal mammal) (STV 0.95 0.8))")
+    runner.run("!(add-proposition-tv (mammal dog) (STV 1.0 0.9))")
+    runner.run("!(add-proposition-tv (dog Fido1) (STV 1.0 0.9))")
     assert _truthy(runner.run("!(find-evidence-for (animal Fido1))"))
 
 


### PR DESCRIPTION
## Summary
- PeTTa's `add-atom` returns `true` not `()`, so `let () (add-atom ...) ...` silently fails
- Fix: `let ()` → `let $_` in `inference-petta.metta`
- Tests now use `add-proposition-tv` directly instead of manual split workaround