### PR TITLE
Capture MeTTa inference traces + lazy HF download

### DIFF
--- a/metta_nl_corpus/services/defs/ingestion/assets.py
+++ b/metta_nl_corpus/services/defs/ingestion/assets.py
@@ -1,3 +1,4 @@
+from functools import cache
 from pathlib import Path
 
 import polars as pl
@@ -21,15 +22,22 @@ logger = getLogger(__name__)
 SUBSET_SIZE = 50
 
 
-training_dataset_path = hf_hub_download(
-    repo_id="stanfordnlp/snli",
-    filename="plain_text/train-00000-of-00001.parquet",
-    repo_type="dataset",
-)
+@cache
+def _get_training_dataset_path() -> str:
+    """Resolve the SNLI training parquet path, downloading from HF on first call.
+
+    Lazily invoked so importing this module does not require network access
+    (tests, type-checking, MCP server bootstrap all import this transitively).
+    """
+    return hf_hub_download(
+        repo_id="stanfordnlp/snli",
+        filename="plain_text/train-00000-of-00001.parquet",
+        repo_type="dataset",
+    )
 
 
 class BaseConfig(Config):
-    training_dataset: str = training_dataset_path
+    training_dataset: str | None = None  # falls back to HF SNLI when unset
     version: str | None = None  # <None> for all versions
 
 
@@ -53,7 +61,7 @@ load_parquet_from_path = to_boxed_path_loader(pl.read_parquet)
 def raw_training_data(
     context: AssetExecutionContext, config: BaseConfig
 ) -> pl.DataFrame:
-    file_path = Path(training_dataset_path)
+    file_path = Path(config.training_dataset or _get_training_dataset_path())
     df = (
         load_parquet_from_path(file_path)
         | with_context(context)


### PR DESCRIPTION
## Summary

- **Inference traces on validation records.** `Validation` now carries `expressions_added` (JSON list of `!(add-proposition ...)` calls fed to the MeTTa runner) and `inference_result` (str repr of `runner.run(expression_to_evaluate)` — the actual proof / inference chain). Previously the runner's result was logged and thrown away; we stored only a boolean.
- **Lazy SNLI download.** `hf_hub_download` was called at module import, which blocked tests, the MCP server bootstrap on cold uv caches, and any sandbox without HuggingFace reachability. Now wrapped in `@cache`'d `_get_training_dataset_path()` and only invoked when `raw_training_data` runs. `BaseConfig.training_dataset` is now actually honored when set (it was being ignored).
- **Storage migration extended** to cover the `validations` table so existing DBs gain the new columns on next open.
- **Housekeeping:** `datasets/` added to `.gitignore` (runtime SQLite artifact); branch naming convention noted in `CLAUDE.md`.

Public bool-returning `validate_expressions_*` signatures are preserved as thin wrappers over new `_*_trace` internals, so MCP/CLI callers that serialize `is_valid` into response dicts are unaffected.

## Why this matters

The trace is the most valuable signal a downstream neural-symbolic consumer can train on — atom embeddings, proof-step prediction, retrospective re-analysis — and recomputing it later means re-executing every MeTTa validation. Capturing it now is a one-pass cost.

## Test plan

- [x] `uv run pytest tests/` — 94 passed, 21 skipped (2 pre-existing failures in `test_pydantic_ai_agent.py` need `OPENAI_API_KEY`, unrelated)
- [x] `validate_expressions_are_entailing/_contradictory` smoke tests pass against the new internals
- [x] Storage migration verified on an old-schema DB: both new columns added
- [x] Full round-trip insert/select of trace fields through SQLite
- [x] `import metta_nl_corpus.services.defs.ingestion.assets` succeeds with no network access
- [ ] Run a small pipeline batch end-to-end and confirm trace fields land in the validations table (requires `OPENAI_API_KEY` or Ollama, not run in sandbox)

https://claude.ai/code/session_01D5fwsNtoiRRtg8Fth3Xyua

---
_Generated by [Claude Code](https://claude.ai/code/session_01D5fwsNtoiRRtg8Fth3Xyua)_